### PR TITLE
fix: only fill and authenticate makers that have not responded

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1847,7 +1847,7 @@ jobs:
   test-reference-maker:
     needs: build-images
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: read
@@ -1961,6 +1961,7 @@ jobs:
           BITCOIN_RPC_URL: http://127.0.0.1:18445
           BITCOIN_RPC_USER: test
           BITCOIN_RPC_PASSWORD: test
+          OBWATCH_URL: http://127.0.0.1:8080
         run: |
           pytest -c pytest.ini -m reference_maker --junitxml=junit/test-results.xml \
             --cov --cov-report=term-missing --cov-report=xml \
@@ -1986,6 +1987,9 @@ jobs:
           echo ""
           echo "=== JAM Maker2 logs ==="
           docker compose logs jam-maker2 --tail=100
+          echo ""
+          echo "=== NG replacement maker logs ==="
+          docker compose logs maker3 --tail=100 || true
 
       - name: Cleanup
         if: always()

--- a/docs/technical/protocol.md
+++ b/docs/technical/protocol.md
@@ -95,6 +95,15 @@ Additional per-maker checks at this stage (all cause the offending maker to be d
 
 The `!hp2` broadcast is sent *after* `!ioauth`, not before. This is intentional: broadcasting early would risk other makers in the same transaction seeing the commitment and blacklisting it before they have processed the same taker's `!auth`, causing spurious rejections.
 
+If an auth pass has revealed a proof and replacements are selected, the taker
+uses one fresh PoDLE commitment for that replacement wave, including any
+partial mini-fill batches before the next auth pass. Already-authenticated
+makers retain their established sessions and are not sent the replacement
+proof. Later transaction and signature phases do not use the PoDLE commitment.
+This avoids presenting a commitment that may already have propagated through
+`!hp2`. A compatibility preflight that exits before sending a proof reuses the
+current commitment for its replacements.
+
 For source obfuscation, the maker does not broadcast `!hp2` on its own long-lived directory connection. Instead:
 
 1. Maker opens new connections to all directory servers using a **fresh random nick** and **unique Tor circuit** (via SOCKS5 stream isolation with a random credential)
@@ -243,6 +252,8 @@ When makers fail to respond, the taker can automatically select replacements ins
 - Configuration: `max_maker_replacement_attempts` (default: 3, range: 0-10)
 - Failed makers added to ignored list for the session
 - New makers go through the full fill/auth flow
+- Auth-stage replacements use one fresh PoDLE commitment after a revelation
+  was sent; existing authenticated makers are not re-driven
 - The requested counterparty count remains the replacement target through fill
   and auth. Partial replacement selections are used and the remaining deficit
   is retried while attempts remain.

--- a/scripts/run_parallel_tests.sh
+++ b/scripts/run_parallel_tests.sh
@@ -1469,6 +1469,7 @@ run_suite_reference_maker() {
     local log="${PARALLEL_DIR}/${suite}.log"
     local btc_jam_rpc=$(host_port "$suite" btc_jam_rpc)
     local dir_port=$(host_port "$suite" dir)
+    local obwatch_port=$(host_port "$suite" obwatch)
     local prefix="${CONTAINER_PREFIX}-${suite}"
 
     log_suite "Starting: Reference Maker Tests ($suite)"
@@ -1507,6 +1508,7 @@ run_suite_reference_maker() {
         BITCOIN_RPC_USER=test \
         BITCOIN_RPC_PASSWORD=test \
         DIRECTORY_PORT="${dir_port}" \
+        OBWATCH_URL="http://127.0.0.1:${obwatch_port}" \
         JM_CONTAINER_PREFIX="${prefix}" \
         COMPOSE_PROJECT_NAME="${PROJECT_PREFIX}-${suite}" \
         COVERAGE_FILE=".coverage.${suite}" \
@@ -1517,6 +1519,11 @@ run_suite_reference_maker() {
     ) > "$log" 2>&1
     rc=$?
     set -e
+    if [ "$rc" -ne 0 ]; then
+        dump_suite_logs "$suite" "$rc" "$log" \
+            tor directory directory2 bitcoin-jam jam jam-maker1 jam-maker2 \
+            orderbook-watcher maker3
+    fi
     cleanup_suite "$suite"
     return $rc
 }

--- a/taker/src/taker/coinjoin_session.py
+++ b/taker/src/taker/coinjoin_session.py
@@ -665,6 +665,7 @@ class CoinJoinSession:
                 )
                 return PhaseResult(success=False, failed_makers=incompatible_makers)
 
+        podle_revealed = False
         for nick in pending_nicks:
             session = self.maker_sessions[nick]
             if session.crypto is None:
@@ -712,6 +713,7 @@ class CoinJoinSession:
                 log_routing=True,
                 force_channel=session.comm_channel,
             )
+            podle_revealed = True
 
         timeout = self.config.maker_timeout_sec
         expected_nicks = list(pending_nicks)
@@ -912,9 +914,17 @@ class CoinJoinSession:
 
         if len(self.maker_sessions) < self.config.minimum_makers:
             logger.error(f"Not enough makers sent UTXOs: {len(self.maker_sessions)}")
-            return PhaseResult(success=False, failed_makers=failed_makers)
+            return PhaseResult(
+                success=False,
+                failed_makers=failed_makers,
+                podle_revealed=podle_revealed,
+            )
 
-        return PhaseResult(success=True, failed_makers=failed_makers)
+        return PhaseResult(
+            success=True,
+            failed_makers=failed_makers,
+            podle_revealed=podle_revealed,
+        )
 
     async def _verify_maker_utxos(
         self,

--- a/taker/src/taker/coinjoin_session.py
+++ b/taker/src/taker/coinjoin_session.py
@@ -295,7 +295,7 @@ class CoinJoinSession:
             return 1
         return 0
 
-    def _drop_neutrino_incompatible_sessions(self) -> list[str]:
+    def _drop_neutrino_incompatible_sessions(self, nicks: list[str] | None = None) -> list[str]:
         """Drop sessions for makers whose handshake explicitly lacks neutrino_compat.
 
         Called just after opportunistic direct-peer handshakes complete, to
@@ -307,7 +307,8 @@ class CoinJoinSession:
         Returns the list of dropped nicks (empty if none).
         """
         dropped: list[str] = []
-        for nick in list(self.maker_sessions.keys()):
+        candidates = list(self.maker_sessions.keys()) if nicks is None else list(nicks)
+        for nick in candidates:
             peer = self.directory_client.get_connected_peer(nick)
             if peer is None:
                 continue
@@ -383,8 +384,17 @@ class CoinJoinSession:
         if not self.podle_commitment:
             return PhaseResult(success=False)
 
-        # Create a new crypto session for this CoinJoin
-        self.crypto_session = CryptoSession()
+        # A repeat !fill reuses the commitment, which the maker refuses as already
+        # reserved without replying, so only fill makers that have not responded.
+        pending_nicks = [
+            nick for nick, session in self.maker_sessions.items() if not session.responded_fill
+        ]
+        if not pending_nicks:
+            return PhaseResult(success=len(self.maker_sessions) >= self.config.minimum_makers)
+
+        # Established makers hold the pubkey from their !fill; only a fresh round rotates it.
+        if len(pending_nicks) == len(self.maker_sessions) or self.crypto_session is None:
+            self.crypto_session = CryptoSession()
         taker_pubkey = self.crypto_session.get_pubkey_hex()
         commitment_hex = self.podle_commitment.to_commitment_str()
 
@@ -398,9 +408,9 @@ class CoinJoinSession:
         # 3. Record the channel in maker_session.comm_channel
         # 4. Use only that channel for all subsequent messages
 
-        # Start direct connection attempts for all makers
+        # Start direct connection attempts for the makers being filled
         if self.directory_client.prefer_direct_connections:
-            for nick in self.maker_sessions.keys():
+            for nick in pending_nicks:
                 maker_location = self.directory_client.get_peer_location(nick)
                 if maker_location:
                     self.directory_client.try_direct_connect(nick)
@@ -409,7 +419,7 @@ class CoinJoinSession:
         # This timeout balances privacy (prefer direct) vs latency (don't wait too long)
         if self.directory_client.prefer_direct_connections:
             pending_tasks = []
-            for nick in self.maker_sessions.keys():
+            for nick in pending_nicks:
                 task = self.directory_client.get_pending_connect_task(nick)
                 if task is not None and not task.done():
                     pending_tasks.append(task)
@@ -437,7 +447,7 @@ class CoinJoinSession:
         # or legacy peer with no features field) are kept; the existing check
         # in _phase_auth will catch them later.
         if self.backend.requires_neutrino_metadata():
-            incompatible = self._drop_neutrino_incompatible_sessions()
+            incompatible = self._drop_neutrino_incompatible_sessions(pending_nicks)
             if incompatible and len(self.maker_sessions) < self.config.minimum_makers:
                 logger.error(
                     f"After filtering {len(incompatible)} neutrino-incompatible maker(s), "
@@ -448,12 +458,14 @@ class CoinJoinSession:
                     success=False,
                     failed_makers=incompatible,
                 )
+            pending_nicks = [nick for nick in pending_nicks if nick in self.maker_sessions]
 
         # Determine and record communication channel for each maker by
         # delegating to the directory layer. The DTO encapsulates the
         # "prefer direct, otherwise pick the most relevant directory"
         # algorithm that used to be open-coded here and in two other sites.
-        for nick, session in self.maker_sessions.items():
+        for nick in pending_nicks:
+            session = self.maker_sessions[nick]
             binding = self.directory_client.bind_session(nick)
             if binding is None:
                 # No directories connected -- shouldn't happen at this stage.
@@ -467,9 +479,9 @@ class CoinJoinSession:
                     f"(onion: {binding.peer_location or 'unknown'})"
                 )
 
-        # Send !fill to all makers using their designated channels
         # Format: fill <oid> <amount> <taker_pubkey> <commitment>
-        for nick, session in self.maker_sessions.items():
+        for nick in pending_nicks:
+            session = self.maker_sessions[nick]
             fill_data = f"{session.offer.oid} {self.cj_amount} {taker_pubkey} {commitment_hex}"
             channel = await self.directory_client.send_privmsg(
                 nick, "fill", fill_data, log_routing=True, force_channel=session.comm_channel
@@ -477,9 +489,8 @@ class CoinJoinSession:
             # Verify the channel used matches what we recorded
             assert channel == session.comm_channel, f"Channel mismatch for {nick}"
 
-        # Wait for all !pubkey responses at once
         timeout = self.config.maker_timeout_sec
-        expected_nicks = list(self.maker_sessions.keys())
+        expected_nicks = list(pending_nicks)
 
         responses = await self.directory_client.wait_for_responses(
             expected_nicks=expected_nicks,
@@ -503,7 +514,7 @@ class CoinJoinSession:
         # Maker sends: "<nacl_pubkey> [features=...] <signing_pubkey> <signature>"
         # Directory client strips command, we get the data part
         # Note: responses may include error responses with {"error": True, "data": "reason"}
-        for nick in list(self.maker_sessions.keys()):
+        for nick in pending_nicks:
             if nick in responses:
                 # Check if this is an error response
                 if responses[nick].get("error"):
@@ -560,7 +571,9 @@ class CoinJoinSession:
         # replacement machinery find a substitute. The auth-phase check stays
         # as a safety net for replacement paths.
         if self.backend.requires_neutrino_metadata():
-            for nick in list(self.maker_sessions.keys()):
+            for nick in pending_nicks:
+                if nick not in self.maker_sessions:
+                    continue
                 session = self.maker_sessions[nick]
                 if session.responded_fill and not session.supports_neutrino_compat:
                     logger.warning(
@@ -595,6 +608,14 @@ class CoinJoinSession:
         if not self.podle_commitment:
             return PhaseResult(success=False)
 
+        # A repeat !auth reaches a maker session that has left PUBKEY_SENT and is
+        # rejected, so only authenticate makers that have not responded.
+        pending_nicks = [
+            nick for nick, session in self.maker_sessions.items() if not session.responded_auth
+        ]
+        if not pending_nicks:
+            return PhaseResult(success=len(self.maker_sessions) >= self.config.minimum_makers)
+
         # Send !auth to each maker with format based on their feature support.
         # - Makers with neutrino_compat: MUST receive extended format
         #   (txid:vout:scriptpubkey:blockheight)
@@ -618,7 +639,8 @@ class CoinJoinSession:
         # the caller can add them to the ignored list and select replacements.
         incompatible_makers: list[str] = []
 
-        for nick, session in list(self.maker_sessions.items()):
+        for nick in list(pending_nicks):
+            session = self.maker_sessions[nick]
             if session.crypto is None:
                 logger.error(f"No encryption session for {nick}")
                 continue
@@ -690,9 +712,8 @@ class CoinJoinSession:
             )
             return PhaseResult(success=False, failed_makers=incompatible_makers)
 
-        # Wait for all !ioauth responses at once
         timeout = self.config.maker_timeout_sec
-        expected_nicks = list(self.maker_sessions.keys())
+        expected_nicks = [nick for nick in pending_nicks if nick in self.maker_sessions]
 
         responses = await self.directory_client.wait_for_responses(
             expected_nicks=expected_nicks,
@@ -711,7 +732,7 @@ class CoinJoinSession:
         # - Legacy format: txid:vout,txid:vout,...
         # - Extended format (neutrino_compat): txid:vout:scriptpubkey:blockheight,...
         # Response format from directory: "<encrypted_data> <signing_pubkey> <signature>"
-        for nick in list(self.maker_sessions.keys()):
+        for nick in expected_nicks:
             if nick in responses:
                 # Explicit protocol error from the maker (e.g. "Failed to
                 # select UTXOs"). Error payloads are plaintext, so handle them

--- a/taker/src/taker/coinjoin_session.py
+++ b/taker/src/taker/coinjoin_session.py
@@ -635,23 +635,16 @@ class CoinJoinSession:
         has_metadata = self.podle_commitment.has_neutrino_metadata()
         taker_requires_extended = self.backend.requires_neutrino_metadata()
 
-        # Makers dropped for lacking a required feature. Reported as failed so
-        # the caller can add them to the ignored list and select replacements.
+        # Remove incompatible makers before sending any !auth. Otherwise, if
+        # filtering drops the session below the maker floor, a replacement pass
+        # would resend !auth to compatible makers whose responses were not read.
         incompatible_makers: list[str] = []
+        if taker_requires_extended:
+            for nick in list(pending_nicks):
+                session = self.maker_sessions[nick]
+                if session.supports_neutrino_compat:
+                    continue
 
-        for nick in list(pending_nicks):
-            session = self.maker_sessions[nick]
-            if session.crypto is None:
-                logger.error(f"No encryption session for {nick}")
-                continue
-
-            maker_requires_extended = session.supports_neutrino_compat
-
-            # Fail early if taker needs extended format but maker doesn't support it.
-            # This happens when taker uses Neutrino backend but maker doesn't advertise
-            # neutrino_compat (e.g., reference implementation makers). Without extended
-            # metadata, the taker cannot verify the maker's UTXOs via block filters.
-            if taker_requires_extended and not maker_requires_extended:
                 logger.error(
                     f"Incompatible maker {nick}: taker uses Neutrino backend but maker "
                     f"doesn't support neutrino_compat. Taker cannot verify maker's UTXOs "
@@ -659,7 +652,26 @@ class CoinJoinSession:
                 )
                 incompatible_makers.append(nick)
                 del self.maker_sessions[nick]
+
+            pending_nicks = [nick for nick in pending_nicks if nick in self.maker_sessions]
+
+            # Report incompatible makers as failed so the replacement loop can
+            # ignore them and pick substitutes before any PoDLE proof is revealed.
+            if len(self.maker_sessions) < self.config.minimum_makers:
+                logger.error(
+                    f"Not enough compatible makers: {len(self.maker_sessions)} "
+                    f"< {self.config.minimum_makers}. Neutrino takers require makers that "
+                    f"provide extended UTXO metadata (neutrino_compat)."
+                )
+                return PhaseResult(success=False, failed_makers=incompatible_makers)
+
+        for nick in pending_nicks:
+            session = self.maker_sessions[nick]
+            if session.crypto is None:
+                logger.error(f"No encryption session for {nick}")
                 continue
+
+            maker_requires_extended = session.supports_neutrino_compat
 
             # Send extended format if:
             # 1. We have the metadata AND
@@ -701,19 +713,8 @@ class CoinJoinSession:
                 force_channel=session.comm_channel,
             )
 
-        # Check if we still have enough makers after filtering incompatible ones.
-        # The incompatible makers are reported as failed so the replacement loop
-        # in _run_auth_with_replacements can ignore them and pick substitutes.
-        if len(self.maker_sessions) < self.config.minimum_makers:
-            logger.error(
-                f"Not enough compatible makers: {len(self.maker_sessions)} "
-                f"< {self.config.minimum_makers}. Neutrino takers require makers that "
-                f"provide extended UTXO metadata (neutrino_compat)."
-            )
-            return PhaseResult(success=False, failed_makers=incompatible_makers)
-
         timeout = self.config.maker_timeout_sec
-        expected_nicks = [nick for nick in pending_nicks if nick in self.maker_sessions]
+        expected_nicks = list(pending_nicks)
 
         responses = await self.directory_client.wait_for_responses(
             expected_nicks=expected_nicks,

--- a/taker/src/taker/models.py
+++ b/taker/src/taker/models.py
@@ -70,6 +70,9 @@ class PhaseResult:
     # or out-of-sync maker -> ignore + replace the maker) from "majority blacklist
     # rejection" (commitment really is known -> rotate commitment).
     blacklist_makers: list[str] = Field(default_factory=list)
+    # True once this auth pass has sent a PoDLE revelation to at least one maker.
+    # Auth-stage replacements must use a fresh commitment after that point.
+    podle_revealed: bool = False
 
     @property
     def needs_replacement(self) -> bool:

--- a/taker/src/taker/taker.py
+++ b/taker/src/taker/taker.py
@@ -1244,6 +1244,7 @@ class Taker(TakerMonitoringMixin):
 
             if not await self._run_auth_with_replacements(
                 required_features=required_features,
+                get_private_key=get_private_key,
                 max_replacement_attempts=max_replacement_attempts,
             ):
                 return None
@@ -1387,7 +1388,10 @@ class Taker(TakerMonitoringMixin):
         return manually_selected_utxos
 
     async def _run_auth_with_replacements(
-        self, required_features: set[str] | None, max_replacement_attempts: int
+        self,
+        required_features: set[str] | None,
+        get_private_key: Any,
+        max_replacement_attempts: int,
     ) -> bool:
         self.state = TakerState.AUTHENTICATING
         logger.info("Phase 2: Sending !auth and receiving !ioauth...")
@@ -1420,6 +1424,7 @@ class Taker(TakerMonitoringMixin):
                 return False
 
             added_replacements = False
+            replacement_commitment_ready = not auth_result.podle_revealed
             while (
                 current_makers < target_makers
                 and auth_replacement_attempt < max_replacement_attempts
@@ -1448,6 +1453,11 @@ class Taker(TakerMonitoringMixin):
                         f"Auth replacement selection is partial: found {len(replacement_offers)}, "
                         f"need {needed}; retrying the remaining deficit after mini-fill"
                     )
+
+                if not replacement_commitment_ready:
+                    if not self._rotate_commitment_for_auth_replacement(get_private_key):
+                        break
+                    replacement_commitment_ready = True
 
                 before_mini_fill = current_makers
                 if not await self._fill_replacement_makers(replacement_offers, failed_nicks):
@@ -1480,6 +1490,31 @@ class Taker(TakerMonitoringMixin):
             self._session.last_failure_reason = reason
             self.state = TakerState.FAILED
             return False
+
+    def _rotate_commitment_for_auth_replacement(self, get_private_key: Any) -> bool:
+        """Prepare a fresh PoDLE proof after an auth-stage commitment disclosure."""
+        if any(
+            not maker_session.responded_auth
+            for maker_session in self._session.maker_sessions.values()
+        ):
+            logger.error("Cannot rotate PoDLE while an unauthenticated maker session remains")
+            return False
+
+        new_commitment = self.podle_manager.generate_fresh_commitment(
+            wallet_utxos=self._session.preselected_utxos,
+            cj_amount=self._session.cj_amount,
+            private_key_getter=get_private_key,
+            min_confirmations=self.config.taker_utxo_age,
+            min_percent=self.config.taker_utxo_amtpercent,
+            max_retries=self.config.taker_utxo_retries,
+        )
+        if new_commitment is None:
+            logger.warning("No fresh PoDLE commitment remains for auth-stage maker replacement")
+            return False
+
+        self._session.podle_commitment = new_commitment
+        logger.info("Rotated PoDLE commitment for auth-stage maker replacement")
+        return True
 
     async def _fill_replacement_makers(
         self, replacement_offers: dict[str, Any], failed_nicks: set[str]

--- a/taker/tests/test_taker_protocol.py
+++ b/taker/tests/test_taker_protocol.py
@@ -2594,7 +2594,9 @@ class TestNeutrinoIncompatibleMakerReplacement:
         assert result.needs_replacement is True
         # The compatible maker stays in the session for the replacement pass.
         assert set(taker._session.maker_sessions.keys()) == {"J5good"}
-        # The early return fires before waiting for !ioauth responses.
+        # The incompatibility preflight fires before revealing the PoDLE
+        # commitment or waiting for !ioauth responses.
+        taker.directory_client.send_privmsg.assert_not_awaited()
         taker.directory_client.wait_for_responses.assert_not_awaited()
 
     def test_process_pubkey_response_parses_features(self):

--- a/taker/tests/test_taker_protocol.py
+++ b/taker/tests/test_taker_protocol.py
@@ -2592,6 +2592,7 @@ class TestNeutrinoIncompatibleMakerReplacement:
         assert result.success is False
         assert result.failed_makers == ["J5legacy"]
         assert result.needs_replacement is True
+        assert result.podle_revealed is False
         # The compatible maker stays in the session for the replacement pass.
         assert set(taker._session.maker_sessions.keys()) == {"J5good"}
         # The incompatibility preflight fires before revealing the PoDLE
@@ -2726,6 +2727,8 @@ class TestNeutrinoIncompatibleMakerReplacement:
         taker._session.cj_amount = 1_000_000
         taker._session.crypto_session = CryptoSession()
         taker._session.podle_commitment.to_commitment_str = MagicMock(return_value="ab" * 32)
+        original_commitment = taker._session.podle_commitment
+        taker.podle_manager = MagicMock()
 
         compatible = MakerSession(
             nick="J5good", offer=_simple_offer("J5good"), supports_neutrino_compat=True
@@ -2764,7 +2767,9 @@ class TestNeutrinoIncompatibleMakerReplacement:
         )
 
         ok = await taker._run_auth_with_replacements(
-            required_features={"neutrino_compat"}, max_replacement_attempts=3
+            required_features={"neutrino_compat"},
+            get_private_key=MagicMock(),
+            max_replacement_attempts=3,
         )
 
         assert ok is True
@@ -2778,6 +2783,10 @@ class TestNeutrinoIncompatibleMakerReplacement:
         assert new_session.supports_neutrino_compat is True
         assert new_session.responded_fill is True
         assert new_session.crypto is not None
+        assert taker._session.podle_commitment is original_commitment
+        taker.podle_manager.generate_fresh_commitment.assert_not_called()
+        fill_data = taker.directory_client.send_privmsg.await_args.args[2]
+        assert fill_data.endswith("ab" * 32)
 
     @pytest.mark.asyncio
     async def test_auth_replacement_retries_when_replacement_does_not_respond(self):
@@ -2831,7 +2840,9 @@ class TestNeutrinoIncompatibleMakerReplacement:
         )
 
         ok = await taker._run_auth_with_replacements(
-            required_features={"neutrino_compat"}, max_replacement_attempts=3
+            required_features={"neutrino_compat"},
+            get_private_key=MagicMock(),
+            max_replacement_attempts=3,
         )
 
         assert ok is True
@@ -2877,7 +2888,9 @@ class TestNeutrinoIncompatibleMakerReplacement:
         taker.directory_client.wait_for_responses = AsyncMock(return_value={})
 
         ok = await taker._run_auth_with_replacements(
-            required_features={"neutrino_compat"}, max_replacement_attempts=2
+            required_features={"neutrino_compat"},
+            get_private_key=MagicMock(),
+            max_replacement_attempts=2,
         )
 
         assert ok is False
@@ -2906,6 +2919,7 @@ class TestNeutrinoIncompatibleMakerReplacement:
         assert result.success is False
         assert result.failed_makers == ["J5err"]
         assert result.needs_replacement is True
+        assert result.podle_revealed is True
         assert "J5err" not in taker._session.maker_sessions
 
 
@@ -3082,7 +3096,9 @@ class TestReplacementTargetRestoration:
         taker._fill_replacement_makers = AsyncMock(side_effect=mini_fill)
 
         ok = await taker._run_auth_with_replacements(
-            required_features=None, max_replacement_attempts=2
+            required_features=None,
+            get_private_key=MagicMock(),
+            max_replacement_attempts=2,
         )
 
         assert ok is True
@@ -3093,15 +3109,27 @@ class TestReplacementTargetRestoration:
     @pytest.mark.asyncio
     async def test_auth_uses_partial_batches_for_remaining_target_deficit(self):
         taker = self._make_taker(minimum_makers=8, target_makers=10, current_makers=8)
+        for maker_session in taker._session.maker_sessions.values():
+            maker_session.responded_auth = True
+        fresh_commitment = MagicMock()
+        taker._session.preselected_utxos = [MagicMock()]
+        taker.podle_manager = MagicMock()
+        taker.podle_manager.generate_fresh_commitment.return_value = fresh_commitment
         taker._session._phase_auth = AsyncMock(
-            side_effect=[PhaseResult(success=True), PhaseResult(success=True)]
+            side_effect=[
+                PhaseResult(success=True, podle_revealed=True),
+                PhaseResult(success=True),
+            ]
         )
         taker.orderbook_manager.select_makers.side_effect = [
             (self._replacement_offers("J5replacement1"), 0),
             (self._replacement_offers("J5replacement2"), 0),
         ]
 
+        commitments_seen_by_fill = []
+
         async def mini_fill(replacement_offers, failed_nicks):
+            commitments_seen_by_fill.append(taker._session.podle_commitment)
             for nick, offer in replacement_offers.items():
                 taker._session.maker_sessions[nick] = MakerSession(nick=nick, offer=offer)
             return True
@@ -3109,7 +3137,9 @@ class TestReplacementTargetRestoration:
         taker._fill_replacement_makers = AsyncMock(side_effect=mini_fill)
 
         ok = await taker._run_auth_with_replacements(
-            required_features=None, max_replacement_attempts=2
+            required_features=None,
+            get_private_key=MagicMock(),
+            max_replacement_attempts=2,
         )
 
         assert ok is True
@@ -3119,6 +3149,8 @@ class TestReplacementTargetRestoration:
         assert selected_counts == [2, 1]
         assert taker._fill_replacement_makers.await_count == 2
         assert taker._session._phase_auth.await_count == 2
+        assert commitments_seen_by_fill == [fresh_commitment, fresh_commitment]
+        taker.podle_manager.generate_fresh_commitment.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_auth_falls_back_at_floor_and_fails_below_floor(self):
@@ -3127,7 +3159,9 @@ class TestReplacementTargetRestoration:
         floor_taker.orderbook_manager.select_makers.return_value = ({}, 0)
 
         floor_ok = await floor_taker._run_auth_with_replacements(
-            required_features=None, max_replacement_attempts=0
+            required_features=None,
+            get_private_key=MagicMock(),
+            max_replacement_attempts=0,
         )
 
         below_floor_taker = self._make_taker(minimum_makers=8, target_makers=9, current_makers=7)
@@ -3137,7 +3171,9 @@ class TestReplacementTargetRestoration:
         below_floor_taker.orderbook_manager.select_makers.return_value = ({}, 0)
 
         below_floor_ok = await below_floor_taker._run_auth_with_replacements(
-            required_features=None, max_replacement_attempts=2
+            required_features=None,
+            get_private_key=MagicMock(),
+            max_replacement_attempts=2,
         )
 
         assert floor_ok is True
@@ -3145,6 +3181,223 @@ class TestReplacementTargetRestoration:
         assert below_floor_ok is False
         assert below_floor_taker.state is TakerState.FAILED
         assert below_floor_taker._session.last_failure_reason is not None
+
+    @pytest.mark.asyncio
+    async def test_auth_replacement_rotates_revealed_commitment_before_mini_fill(self):
+        taker = self._make_taker(minimum_makers=1, target_makers=2, current_makers=1)
+        survivor = next(iter(taker._session.maker_sessions.values()))
+        survivor.responded_auth = True
+        old_commitment = MagicMock(name="old_commitment")
+        fresh_commitment = MagicMock(name="fresh_commitment")
+        taker._session.podle_commitment = old_commitment
+        taker._session.preselected_utxos = [MagicMock()]
+        taker.podle_manager = MagicMock()
+        taker.podle_manager.generate_fresh_commitment.return_value = fresh_commitment
+        taker._session._phase_auth = AsyncMock(
+            side_effect=[
+                PhaseResult(
+                    success=True,
+                    failed_makers=["J5failed"],
+                    podle_revealed=True,
+                ),
+                PhaseResult(success=True),
+            ]
+        )
+        taker.orderbook_manager.select_makers.return_value = (
+            self._replacement_offers("J5replacement"),
+            0,
+        )
+        commitments_seen_by_fill = []
+
+        async def mini_fill(replacement_offers, failed_nicks):
+            commitments_seen_by_fill.append(taker._session.podle_commitment)
+            for nick, offer in replacement_offers.items():
+                taker._session.maker_sessions[nick] = MakerSession(nick=nick, offer=offer)
+            return True
+
+        taker._fill_replacement_makers = AsyncMock(side_effect=mini_fill)
+        get_private_key = MagicMock()
+
+        ok = await taker._run_auth_with_replacements(
+            required_features=None,
+            get_private_key=get_private_key,
+            max_replacement_attempts=2,
+        )
+
+        assert ok is True
+        assert commitments_seen_by_fill == [fresh_commitment]
+        assert taker._session.podle_commitment is fresh_commitment
+        taker.podle_manager.generate_fresh_commitment.assert_called_once_with(
+            wallet_utxos=taker._session.preselected_utxos,
+            cj_amount=taker._session.cj_amount,
+            private_key_getter=get_private_key,
+            min_confirmations=taker.config.taker_utxo_age,
+            min_percent=taker.config.taker_utxo_amtpercent,
+            max_retries=taker.config.taker_utxo_retries,
+        )
+
+    @pytest.mark.asyncio
+    async def test_auth_replacement_rotates_again_for_later_disclosed_wave(self):
+        taker = self._make_taker(minimum_makers=1, target_makers=2, current_makers=1)
+        survivor = next(iter(taker._session.maker_sessions.values()))
+        survivor.responded_auth = True
+        old_commitment = MagicMock(name="old_commitment")
+        first_fresh_commitment = MagicMock(name="first_fresh_commitment")
+        second_fresh_commitment = MagicMock(name="second_fresh_commitment")
+        taker._session.podle_commitment = old_commitment
+        taker._session.preselected_utxos = [MagicMock()]
+        taker.podle_manager = MagicMock()
+        taker.podle_manager.generate_fresh_commitment.side_effect = [
+            first_fresh_commitment,
+            second_fresh_commitment,
+        ]
+
+        auth_call = 0
+
+        async def auth_with_two_failed_waves():
+            nonlocal auth_call
+            auth_call += 1
+            if auth_call == 1:
+                return PhaseResult(
+                    success=True,
+                    failed_makers=["J5initial-failure"],
+                    podle_revealed=True,
+                )
+            if auth_call == 2:
+                del taker._session.maker_sessions["J5replacement1"]
+                return PhaseResult(
+                    success=True,
+                    failed_makers=["J5replacement1"],
+                    podle_revealed=True,
+                )
+            taker._session.maker_sessions["J5replacement2"].responded_auth = True
+            return PhaseResult(success=True)
+
+        taker._session._phase_auth = AsyncMock(side_effect=auth_with_two_failed_waves)
+        taker.orderbook_manager.select_makers.side_effect = [
+            (self._replacement_offers("J5replacement1"), 0),
+            (self._replacement_offers("J5replacement2"), 0),
+        ]
+        commitments_seen_by_fill = []
+
+        async def mini_fill(replacement_offers, failed_nicks):
+            commitments_seen_by_fill.append(taker._session.podle_commitment)
+            for nick, offer in replacement_offers.items():
+                taker._session.maker_sessions[nick] = MakerSession(nick=nick, offer=offer)
+            return True
+
+        taker._fill_replacement_makers = AsyncMock(side_effect=mini_fill)
+
+        ok = await taker._run_auth_with_replacements(
+            required_features=None,
+            get_private_key=MagicMock(),
+            max_replacement_attempts=2,
+        )
+
+        assert ok is True
+        assert commitments_seen_by_fill == [
+            first_fresh_commitment,
+            second_fresh_commitment,
+        ]
+        assert taker._session.podle_commitment is second_fresh_commitment
+        assert taker.podle_manager.generate_fresh_commitment.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_auth_replacement_at_floor_when_fresh_commitments_exhausted(self):
+        taker = self._make_taker(minimum_makers=1, target_makers=2, current_makers=1)
+        survivor = next(iter(taker._session.maker_sessions.values()))
+        survivor.responded_auth = True
+        taker._session.podle_commitment = MagicMock()
+        taker.podle_manager = MagicMock()
+        taker.podle_manager.generate_fresh_commitment.return_value = None
+        taker._session._phase_auth = AsyncMock(
+            return_value=PhaseResult(
+                success=True,
+                failed_makers=["J5failed"],
+                podle_revealed=True,
+            )
+        )
+        taker.orderbook_manager.select_makers.return_value = (
+            self._replacement_offers("J5replacement"),
+            0,
+        )
+        taker._fill_replacement_makers = AsyncMock()
+
+        ok = await taker._run_auth_with_replacements(
+            required_features=None,
+            get_private_key=MagicMock(),
+            max_replacement_attempts=1,
+        )
+
+        assert ok is True
+        taker._fill_replacement_makers.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auth_replacement_fails_below_floor_when_fresh_commitments_exhausted(self):
+        taker = self._make_taker(minimum_makers=2, target_makers=3, current_makers=1)
+        survivor = next(iter(taker._session.maker_sessions.values()))
+        survivor.responded_auth = True
+        taker._session.podle_commitment = MagicMock()
+        taker.podle_manager = MagicMock()
+        taker.podle_manager.generate_fresh_commitment.return_value = None
+        taker._session._phase_auth = AsyncMock(
+            return_value=PhaseResult(
+                success=False,
+                failed_makers=["J5failed"],
+                podle_revealed=True,
+            )
+        )
+        taker.orderbook_manager.select_makers.return_value = (
+            self._replacement_offers("J5replacement"),
+            0,
+        )
+        taker._fill_replacement_makers = AsyncMock()
+
+        ok = await taker._run_auth_with_replacements(
+            required_features=None,
+            get_private_key=MagicMock(),
+            max_replacement_attempts=1,
+        )
+
+        assert ok is False
+        assert taker.state is TakerState.FAILED
+        taker._fill_replacement_makers.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auth_replacement_before_revelation_reuses_commitment(self):
+        taker = self._make_taker(minimum_makers=1, target_makers=2, current_makers=1)
+        original_commitment = MagicMock(name="original_commitment")
+        taker._session.podle_commitment = original_commitment
+        taker.podle_manager = MagicMock()
+        taker._session._phase_auth = AsyncMock(
+            side_effect=[
+                PhaseResult(success=False, failed_makers=["J5incompatible"]),
+                PhaseResult(success=True),
+            ]
+        )
+        taker.orderbook_manager.select_makers.return_value = (
+            self._replacement_offers("J5replacement"),
+            0,
+        )
+        commitments_seen_by_fill = []
+
+        async def mini_fill(replacement_offers, failed_nicks):
+            commitments_seen_by_fill.append(taker._session.podle_commitment)
+            for nick, offer in replacement_offers.items():
+                taker._session.maker_sessions[nick] = MakerSession(nick=nick, offer=offer)
+            return True
+
+        taker._fill_replacement_makers = AsyncMock(side_effect=mini_fill)
+
+        ok = await taker._run_auth_with_replacements(
+            required_features={"neutrino_compat"},
+            get_private_key=MagicMock(),
+            max_replacement_attempts=1,
+        )
+
+        assert ok is True
+        assert commitments_seen_by_fill == [original_commitment]
+        taker.podle_manager.generate_fresh_commitment.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_majority_blacklist_rotates_before_floor_fallback(self):
@@ -3349,3 +3602,23 @@ class TestIncrementalPhaseTopUp:
         expected = taker.directory_client.wait_for_responses.await_args.kwargs["expected_nicks"]
         assert expected == ["J5new"]
         assert result.failed_makers == ["J5new"]
+
+    @pytest.mark.asyncio
+    async def test_auth_replacement_fill_serializes_current_commitment(self):
+        taker = self._make_taker(minimum_makers=1)
+        taker._session.cj_amount = 1_000_000
+        taker._session.crypto_session = CryptoSession()
+        fresh_commitment = MagicMock()
+        fresh_commitment.to_commitment_str.return_value = "P" + "cd" * 32
+        taker._session.podle_commitment = fresh_commitment
+        replacement_crypto = CryptoSession()
+        taker.directory_client.wait_for_responses = AsyncMock(
+            return_value={"J5new": {"data": f"{replacement_crypto.get_pubkey_hex()} signpk sig"}}
+        )
+
+        ok = await taker._fill_replacement_makers({"J5new": _simple_offer("J5new")}, set())
+
+        assert ok is True
+        fill_call = taker.directory_client.send_privmsg.await_args
+        assert fill_call.args[0:2] == ("J5new", "fill")
+        assert fill_call.args[2].endswith("P" + "cd" * 32)

--- a/taker/tests/test_taker_protocol.py
+++ b/taker/tests/test_taker_protocol.py
@@ -3185,3 +3185,165 @@ class TestReplacementTargetRestoration:
         assert ok is True
         assert taker._session._phase_fill.await_count == 2
         taker.podle_manager.generate_fresh_commitment.assert_called_once()
+
+
+class TestIncrementalPhaseTopUp:
+    """Topping a session back up to the requested maker count must not re-drive
+    a phase against makers that already completed it.
+
+    A repeated !fill carries the same PoDLE commitment, which the maker refuses
+    as "commitment already in use" without replying at all, and a repeated
+    !auth hits a session that is no longer in PUBKEY_SENT. Either way the taker
+    would drop a healthy maker and permanently add it to the ignored list.
+    """
+
+    @staticmethod
+    def _make_taker(minimum_makers: int = 2) -> Taker:
+        from taker.coinjoin_session import CoinJoinSession
+
+        with patch.object(Taker, "__init__", lambda self, *a, **k: None):
+            taker = Taker.__new__(Taker)
+        taker._session = CoinJoinSession()
+        taker._session.attach(taker)
+        taker.wallet = MagicMock()
+        taker.backend = AsyncMock()
+        taker.backend.requires_neutrino_metadata = MagicMock(return_value=False)
+        taker.config = MagicMock()
+        taker.config.minimum_makers = minimum_makers
+        taker.config.maker_timeout_sec = 1
+
+        binding = MagicMock()
+        binding.channel_id = "directory:host:5222"
+        binding.is_direct = False
+        binding.peer_location = None
+
+        dc = MagicMock()
+        dc.prefer_direct_connections = False
+        dc.bind_session = MagicMock(return_value=binding)
+        dc.send_privmsg = AsyncMock(return_value="directory:host:5222")
+        dc.upgrade_channel_prefer_direct = MagicMock(side_effect=lambda n, ch: ch)
+        dc.wait_for_responses = AsyncMock(return_value={})
+        taker.directory_client = dc
+
+        commitment = MagicMock()
+        commitment.has_neutrino_metadata.return_value = True
+        commitment.to_commitment_str.return_value = "ab" * 32
+        commitment.to_revelation.return_value = {
+            "utxo": "a" * 64 + ":0",
+            "P": "00",
+            "P2": "00",
+            "sig": "00",
+            "e": "00",
+        }
+        taker._session.podle_commitment = commitment
+        return taker
+
+    @staticmethod
+    def _filled_maker(nick: str) -> MakerSession:
+        maker = MakerSession(nick=nick, offer=_simple_offer(nick))
+        peer = CryptoSession()
+        maker.pubkey = peer.get_pubkey_hex()
+        maker.crypto = CryptoSession()
+        maker.crypto.setup_encryption(peer.get_pubkey_hex())
+        maker.comm_channel = "directory:host:5222"
+        maker.responded_fill = True
+        return maker
+
+    @pytest.mark.asyncio
+    async def test_phase_fill_only_messages_makers_that_have_not_filled(self):
+        taker = self._make_taker()
+        established = self._filled_maker("J5filled")
+        taker._session.maker_sessions = {
+            "J5filled": established,
+            "J5new": MakerSession(nick="J5new", offer=_simple_offer("J5new")),
+        }
+        taker._session.crypto_session = CryptoSession()
+        replacement_crypto = CryptoSession()
+        taker.directory_client.wait_for_responses = AsyncMock(
+            return_value={"J5new": {"data": f"{replacement_crypto.get_pubkey_hex()} signpk sig"}}
+        )
+
+        result = await taker._session._phase_fill()
+
+        assert result.success is True
+        assert result.failed_makers == []
+        assert set(taker._session.maker_sessions.keys()) == {"J5filled", "J5new"}
+        assert taker._session.maker_sessions["J5filled"] is established
+
+        filled_nicks = [
+            call.args[0] for call in taker.directory_client.send_privmsg.await_args_list
+        ]
+        assert filled_nicks == ["J5new"]
+        expected = taker.directory_client.wait_for_responses.await_args.kwargs["expected_nicks"]
+        assert expected == ["J5new"]
+
+    @pytest.mark.asyncio
+    async def test_phase_fill_keeps_crypto_session_when_topping_up(self):
+        """The established makers hold the taker pubkey from the first !fill, so
+        rotating the crypto session would break their E2E encryption."""
+        taker = self._make_taker()
+        taker._session.maker_sessions = {
+            "J5filled": self._filled_maker("J5filled"),
+            "J5new": MakerSession(nick="J5new", offer=_simple_offer("J5new")),
+        }
+        taker._session.crypto_session = CryptoSession()
+        original_pubkey = taker._session.crypto_session.get_pubkey_hex()
+        replacement_crypto = CryptoSession()
+        taker.directory_client.wait_for_responses = AsyncMock(
+            return_value={"J5new": {"data": f"{replacement_crypto.get_pubkey_hex()} signpk sig"}}
+        )
+
+        await taker._session._phase_fill()
+
+        assert taker._session.crypto_session.get_pubkey_hex() == original_pubkey
+
+    @pytest.mark.asyncio
+    async def test_phase_fill_rotates_crypto_session_for_a_fresh_round(self):
+        """A commitment rotation rebuilds every maker session, and that round
+        must still get a fresh taker keypair."""
+        taker = self._make_taker()
+        taker._session.maker_sessions = {
+            "J5a": MakerSession(nick="J5a", offer=_simple_offer("J5a")),
+            "J5b": MakerSession(nick="J5b", offer=_simple_offer("J5b")),
+        }
+        taker._session.crypto_session = CryptoSession()
+        stale_pubkey = taker._session.crypto_session.get_pubkey_hex()
+        taker.directory_client.wait_for_responses = AsyncMock(
+            return_value={
+                "J5a": {"data": f"{CryptoSession().get_pubkey_hex()} signpk sig"},
+                "J5b": {"data": f"{CryptoSession().get_pubkey_hex()} signpk sig"},
+            }
+        )
+
+        await taker._session._phase_fill()
+
+        assert taker._session.crypto_session.get_pubkey_hex() != stale_pubkey
+
+    @pytest.mark.asyncio
+    async def test_phase_auth_only_messages_makers_that_have_not_authenticated(self):
+        taker = self._make_taker()
+        established = self._filled_maker("J5authed")
+        established.responded_auth = True
+        established.cj_address = "bcrt1qcj"
+        established.change_address = "bcrt1qchange"
+        established.utxos = [{"txid": "c" * 64, "vout": 0, "scriptpubkey": "0014" + "ab" * 20}]
+        replacement = self._filled_maker("J5new")
+        taker._session.maker_sessions = {"J5authed": established, "J5new": replacement}
+        taker._session.crypto_session = CryptoSession()
+
+        result = await taker._session._phase_auth()
+
+        # J5new is the only maker sent !auth, and it does not answer, so it is
+        # the only one dropped.
+        assert set(taker._session.maker_sessions.keys()) == {"J5authed"}
+        assert taker._session.maker_sessions["J5authed"] is established
+        assert established.responded_auth is True
+        assert established.utxos
+
+        authed_nicks = [
+            call.args[0] for call in taker.directory_client.send_privmsg.await_args_list
+        ]
+        assert authed_nicks == ["J5new"]
+        expected = taker.directory_client.wait_for_responses.await_args.kwargs["expected_nicks"]
+        assert expected == ["J5new"]
+        assert result.failed_makers == ["J5new"]

--- a/tests/e2e/test_complete_system.py
+++ b/tests/e2e/test_complete_system.py
@@ -16,7 +16,9 @@ Requires: docker compose --profile e2e up -d
 import asyncio
 import os
 import subprocess
+from collections import Counter
 from pathlib import Path
+from typing import Any
 
 import pytest
 import pytest_asyncio
@@ -25,8 +27,10 @@ from jmwallet.backends.descriptor_wallet import DescriptorWalletBackend
 from jmwallet.wallet.service import WalletService
 from maker.bot import MakerBot
 from maker.config import MakerConfig
-from taker.config import TakerConfig
 from taker.coinjoin_session import CoinJoinSession
+from taker.config import TakerConfig
+from taker.models import PhaseResult
+from taker.orderbook import calculate_cj_fee
 from taker.taker import Taker
 
 # Mark all tests in this module as requiring Docker e2e profile
@@ -76,6 +80,40 @@ GENERIC_TEST_MNEMONIC = (
 
 # Address used for mining blocks (valid P2WPKH on regtest)
 MINING_ADDRESS = "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080"
+
+
+def _wait_for_offer_fee_profiles(
+    expected_fees: set[str], timeout: float = 120.0
+) -> bool:
+    """Wait until the watcher contains every maker fee profile required by a test."""
+    import json
+    import time
+    import urllib.error
+    import urllib.request
+
+    from tests.e2e.docker_utils import get_orderbook_watcher_url
+
+    url = f"{get_orderbook_watcher_url()}/orderbook.json"
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=3) as response:
+                offers = json.loads(response.read().decode("utf-8")).get("offers", [])
+        except (
+            urllib.error.URLError,
+            OSError,
+            json.JSONDecodeError,
+            TimeoutError,
+        ):
+            time.sleep(2)
+            continue
+
+        observed_fees = {str(offer.get("cjfee")) for offer in offers}
+        if expected_fees <= observed_fees:
+            return True
+        time.sleep(2)
+
+    return False
 
 
 def _require_docker_container(service: str) -> None:
@@ -1005,6 +1043,160 @@ async def test_complete_coinjoin_two_makers(
         print("Stopping taker...")
         await taker.stop()
         await taker_wallet.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+@pytest.mark.parametrize("failure_phase", ["fill", "auth"])
+async def test_coinjoin_replaces_failed_maker_without_redriving_survivor(
+    failure_phase,
+    bitcoin_backend,
+    taker_config,
+    directory_server,
+    fresh_docker_makers,
+    monkeypatch,
+):
+    """A real maker replacement must leave the healthy maker's state untouched.
+
+    The selected maker fees identify maker1 and maker2 deterministically. One
+    container is stopped immediately before the chosen phase, and maker3 is the
+    only replacement candidate. Counting the taker's actual directory sends
+    catches duplicate phase messages even if the maker silently ignores them.
+    """
+    from tests.e2e.docker_utils import get_container_name
+    from tests.e2e.rpc_utils import mine_blocks
+
+    for service in ("maker1", "maker2", "maker3"):
+        _require_docker_container(service)
+    assert _wait_for_offer_fee_profiles({"0.0003", "0.00025", "0.0002"}), (
+        "Required maker1, maker2, and maker3 fee profiles did not become ready"
+    )
+
+    await mine_blocks(10, MINING_ADDRESS)
+    wallet = WalletService(
+        mnemonic=TAKER_MNEMONIC,
+        backend=bitcoin_backend,
+        network="regtest",
+        mixdepth_count=5,
+        data_dir=_suite_data_dir(),
+    )
+    await wallet.sync_all()
+
+    config = taker_config.model_copy(
+        update={"maker_timeout_sec": 10, "max_maker_replacement_attempts": 2}
+    )
+    taker = Taker(wallet, bitcoin_backend, config)
+    stopped_container = get_container_name("maker2")
+    stopped = False
+    sent_messages: list[tuple[str, str]] = []
+    selected_nicks: dict[str, str] = {}
+
+    try:
+        await taker.start()
+        taker.orderbook_manager.clear_ignored_makers()
+
+        def select_test_makers(
+            cj_amount: int,
+            n: int,
+            **kwargs: Any,
+        ) -> tuple[dict[str, Any], int]:
+            hard_excludes = kwargs.get("hard_exclude_nicks") or set()
+            fees = ["0.0003", "0.00025"] if not hard_excludes else ["0.0002"]
+            selected: dict[str, Any] = {}
+            for fee in fees:
+                matches = [
+                    offer
+                    for offer in taker.orderbook_manager.offers
+                    if str(offer.cjfee) == fee
+                    and offer.counterparty not in hard_excludes
+                ]
+                assert len(matches) == 1, f"Expected one eligible NG maker at fee {fee}"
+                offer = matches[0]
+                selected[offer.counterparty] = offer
+                selected_nicks[fee] = offer.counterparty
+            assert len(selected) == n
+            total_fee = sum(
+                calculate_cj_fee(offer, cj_amount) for offer in selected.values()
+            )
+            return selected, total_fee
+
+        monkeypatch.setattr(
+            taker.orderbook_manager, "select_makers", select_test_makers
+        )
+
+        original_send = taker.directory_client.send_privmsg
+
+        async def count_send(
+            recipient: str, command: str, *args: Any, **kwargs: Any
+        ) -> str:
+            sent_messages.append((recipient, command))
+            return await original_send(recipient, command, *args, **kwargs)
+
+        monkeypatch.setattr(taker.directory_client, "send_privmsg", count_send)
+
+        original_phase = getattr(CoinJoinSession, f"_phase_{failure_phase}")
+
+        async def stop_failed_maker_then_run_phase(
+            session: CoinJoinSession,
+        ) -> PhaseResult:
+            nonlocal stopped
+            if not stopped:
+                process = await asyncio.create_subprocess_exec(
+                    "docker",
+                    "stop",
+                    stopped_container,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                _, stderr = await asyncio.wait_for(process.communicate(), timeout=30)
+                assert process.returncode == 0, stderr.decode()
+                stopped = True
+            return await original_phase(session)
+
+        monkeypatch.setattr(
+            CoinJoinSession,
+            f"_phase_{failure_phase}",
+            stop_failed_maker_then_run_phase,
+        )
+
+        destination = wallet.get_receive_address(1, 0)
+        txid = await taker.do_coinjoin(
+            amount=50_000_000,
+            destination=destination,
+            mixdepth=0,
+        )
+
+        assert txid is not None
+        await mine_blocks(1, MINING_ADDRESS)
+        failed_nick = selected_nicks["0.00025"]
+        survivor_nick = selected_nicks["0.0003"]
+        replacement_nick = selected_nicks["0.0002"]
+        message_counts = Counter(sent_messages)
+
+        assert message_counts[(survivor_nick, "fill")] == 1
+        assert message_counts[(survivor_nick, "auth")] == 1
+        assert message_counts[(replacement_nick, "fill")] == 1
+        assert message_counts[(replacement_nick, "auth")] == 1
+        assert message_counts[(failed_nick, "fill")] == 1
+        assert message_counts[(failed_nick, "auth")] == (
+            1 if failure_phase == "auth" else 0
+        )
+        assert set(taker._session.maker_sessions) == {survivor_nick, replacement_nick}
+        assert failed_nick in taker.orderbook_manager.ignored_makers
+        assert survivor_nick not in taker.orderbook_manager.ignored_makers
+        assert replacement_nick not in taker.orderbook_manager.ignored_makers
+    finally:
+        if stopped:
+            process = await asyncio.create_subprocess_exec(
+                "docker",
+                "start",
+                stopped_container,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await asyncio.wait_for(process.wait(), timeout=30)
+        await taker.stop()
+        await wallet.close()
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/test_reference_maker_our_taker.py
+++ b/tests/e2e/test_reference_maker_our_taker.py
@@ -19,15 +19,33 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import json
+import os
+import re
 import subprocess
 import tempfile
 import threading
 import time
+import urllib.error
+import urllib.request
+from collections import Counter
+from decimal import Decimal
 from pathlib import Path
+from typing import Any
 
 import pytest
+from jmcore.models import NetworkType
+from jmwallet.backends.descriptor_wallet import DescriptorWalletBackend
+from jmwallet.wallet.service import WalletService
 from loguru import logger
+from pydantic import SecretStr
+from taker.coinjoin_session import CoinJoinSession
+from taker.config import MaxCjFee, TakerConfig
+from taker.models import PhaseResult
+from taker.orderbook import calculate_cj_fee
+from taker.taker import Taker
 
+from tests.e2e.docker_utils import get_orderbook_watcher_url
 from tests.e2e.test_reference_coinjoin import (
     _wait_for_node_sync,
     get_compose_file,
@@ -42,6 +60,10 @@ COINJOIN_TIMEOUT = 300  # Time for CoinJoin to complete
 
 # Directory for yieldgenerator log files
 YIELDGEN_LOG_DIR = Path(tempfile.gettempdir()) / "jm-yieldgen-logs"
+REFERENCE_TAKER_MNEMONIC = (
+    "abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon abandon about"
+)
 
 
 def is_jam_maker_running(maker_id: int = 1) -> bool:
@@ -632,14 +654,9 @@ pytestmark = [
 
 # Default taker funding address derived from default mnemonic: m/84'/1'/0'/0/0
 _TAKER_FUNDING_ADDRESS = "bcrt1q6rz28mcfaxtmd6v789l9rrlrusdprr9pz3cppk"
+_NG_REPLACEMENT_FUNDING_ADDRESS = "bcrt1qe4hmtjq53u7l5vr9uw6sjr9c75ulmklg8jgsj0"
 
-# Indicators used to analyze taker output
-_SUCCESS_INDICATORS = [
-    "coinjoin completed",
-    "transaction broadcast",
-    "txid:",
-    "successfully",
-]
+_TXID_PATTERN = re.compile(r"\btxid\s*[:=]\s*([0-9a-f]{64})\b", re.IGNORECASE)
 
 
 async def _prepare_taker_environment(
@@ -743,7 +760,7 @@ def _analyze_taker_output(
     """Return ``(combined_output, lower_output, has_success)`` for a taker run."""
     combined = result.stdout + result.stderr
     lower = combined.lower()
-    has_success = any(ind in lower for ind in _SUCCESS_INDICATORS)
+    has_success = _TXID_PATTERN.search(combined) is not None
     return combined, lower, has_success
 
 
@@ -853,6 +870,7 @@ def running_yieldgenerators(funded_jam_makers):
         if process:
             processes.append(process)
             started_makers.append(maker)
+            maker["process"] = process
         else:
             # Cleanup any started processes
             for p, m in zip(processes, started_makers, strict=False):
@@ -867,6 +885,92 @@ def running_yieldgenerators(funded_jam_makers):
     logger.info("Stopping yieldgenerators...")
     for process, maker in zip(processes, started_makers, strict=False):
         stop_yieldgenerator(process, maker["maker_id"], maker["wallet_name"])
+
+
+def _wait_for_mixed_maker_offers(
+    timeout: float = 180.0,
+) -> tuple[set[str], str] | None:
+    """Wait until only the expected JAM and NG fee profiles are present."""
+    url = f"{get_orderbook_watcher_url()}/orderbook.json"
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=3) as response:
+                offers = json.loads(response.read().decode("utf-8")).get("offers", [])
+        except (
+            urllib.error.URLError,
+            OSError,
+            json.JSONDecodeError,
+            TimeoutError,
+        ):
+            time.sleep(2)
+            continue
+
+        jam_nicks = {
+            str(offer["counterparty"])
+            for offer in offers
+            if Decimal(str(offer["cjfee"])) < Decimal("0.0001")
+        }
+        replacement_nicks = {
+            str(offer["counterparty"])
+            for offer in offers
+            if Decimal(str(offer["cjfee"])) == Decimal("0.0002")
+        }
+        if len(jam_nicks) == 2 and len(replacement_nicks) == 1:
+            return jam_nicks, replacement_nicks.pop()
+        time.sleep(2)
+
+    return None
+
+
+@pytest.fixture(scope="function")
+def mixed_replacement_makers(running_yieldgenerators):
+    """Run two JAM makers and one NG maker, with guaranteed NG cleanup."""
+    run_compose_cmd(["stop", "maker3"], check=False)
+    clear_ng_state = run_compose_cmd(
+        [
+            "run",
+            "--rm",
+            "--no-deps",
+            "--entrypoint",
+            "sh",
+            "maker3",
+            "-c",
+            (
+                "rm -rf /home/jm/.joinmarket-ng/cmtdata/commitmentlist "
+                "/home/jm/.joinmarket-ng/wallet_metadata.jsonl "
+                "/home/jm/.joinmarket-ng/wallet_metadata_*.jsonl"
+            ),
+        ],
+        check=False,
+    )
+    assert clear_ng_state.returncode == 0, clear_ng_state.stderr
+    assert fund_jam_maker_wallet(_NG_REPLACEMENT_FUNDING_ADDRESS, 2.0), (
+        "Failed to fund the NG replacement maker"
+    )
+    assert _wait_for_node_sync(max_attempts=60), (
+        "NG and JAM Bitcoin nodes must be synchronized before starting maker3"
+    )
+
+    # The reference-maker profile already started maker3's runtime dependencies.
+    # Avoid re-running wallet-funder, which funds every NG test wallet rather than
+    # the single replacement wallet needed by this scenario.
+    start_ng = run_compose_cmd(["up", "-d", "--no-deps", "maker3"], check=False)
+    assert start_ng.returncode == 0, start_ng.stderr
+    try:
+        expected_nicks = _wait_for_mixed_maker_offers()
+        assert expected_nicks is not None, (
+            "Expected fresh offers from two JAM makers and maker3"
+        )
+        jam_nicks, replacement_nick = expected_nicks
+        yield {
+            "makers": running_yieldgenerators,
+            "jam_nicks": jam_nicks,
+            "replacement_nick": replacement_nick,
+        }
+    finally:
+        run_compose_cmd(["stop", "maker3"], check=False)
 
 
 @pytest.mark.asyncio
@@ -927,25 +1031,170 @@ async def test_our_taker_with_reference_makers(
             f"Yieldgenerator logs:\n{maker_output[-3000:]}"
         )
 
-    # For now, we accept if the taker at least tried to connect
-    # Full CoinJoin may fail due to various reasons in test environment
-    connected_to_directory = "connected" in output_lower or "directory" in output_lower
-
-    assert has_success or connected_to_directory, (
-        f"Taker did not successfully run.\n"
+    assert has_success, (
+        f"Taker did not broadcast a CoinJoin transaction.\n"
         f"Exit code: {result.returncode}\n"
         f"Output: {output_combined[-3000:]}\n"
         f"Yieldgenerator logs:\n"
         + "\n".join(get_yieldgenerator_logs(m, tail_lines=50) for m in [1, 2])
     )
+    logger.info("CoinJoin completed successfully with reference makers!")
 
-    if has_success:
-        logger.info("CoinJoin completed successfully with reference makers!")
-    else:
-        logger.warning(
-            "Taker connected but CoinJoin may not have completed. "
-            "Check logs for details."
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(600)
+async def test_our_taker_replaces_failed_reference_maker_without_duplicate_auth(
+    reference_maker_services, mixed_replacement_makers, monkeypatch
+):
+    """Replace a failed JAM maker without re-authenticating the JAM survivor."""
+    compose_file = reference_maker_services["compose_file"]
+    destination = await _prepare_taker_environment(compose_file)
+
+    data_dir = Path(os.environ["JOINMARKET_DATA_DIR"])
+    rpc_url = os.environ.get("BITCOIN_RPC_URL", "http://127.0.0.1:18445")
+    rpc_user = os.environ.get("BITCOIN_RPC_USER", "test")
+    rpc_password = os.environ.get("BITCOIN_RPC_PASSWORD", "test")
+    backend = DescriptorWalletBackend(
+        rpc_url=rpc_url,
+        rpc_user=rpc_user,
+        rpc_password=rpc_password,
+    )
+    wallet = WalletService(
+        mnemonic=REFERENCE_TAKER_MNEMONIC,
+        backend=backend,
+        network="regtest",
+        mixdepth_count=5,
+        data_dir=data_dir,
+    )
+    await wallet.sync_all()
+    config = TakerConfig(
+        mnemonic=SecretStr(REFERENCE_TAKER_MNEMONIC),
+        network=NetworkType.TESTNET,
+        bitcoin_network=NetworkType.REGTEST,
+        backend_type="descriptor_wallet",
+        backend_config={
+            "rpc_url": rpc_url,
+            "rpc_user": rpc_user,
+            "rpc_password": rpc_password,
+        },
+        directory_servers=[f"127.0.0.1:{os.environ.get('DIRECTORY_PORT', '5222')}"],
+        counterparty_count=2,
+        minimum_makers=2,
+        maker_timeout_sec=15,
+        order_wait_time=90.0,
+        max_maker_replacement_attempts=2,
+        max_cj_fee=MaxCjFee(abs_fee=100_000, rel_fee="0.01"),
+        bondless_makers_allowance_require_zero_fee=False,
+        data_dir=data_dir,
+    )
+    taker = Taker(wallet, backend, config)
+    sent_messages: list[tuple[str, str]] = []
+    initial_nicks: set[str] = set()
+    expected_jam_nicks = mixed_replacement_makers["jam_nicks"]
+    expected_replacement_nick = mixed_replacement_makers["replacement_nick"]
+    replacement_nick: str | None = None
+    stopped_legacy = False
+
+    try:
+        await taker.start()
+        taker.orderbook_manager.clear_ignored_makers()
+
+        def select_interop_makers(
+            cj_amount: int,
+            n: int,
+            **kwargs: Any,
+        ) -> tuple[dict[str, Any], int]:
+            nonlocal replacement_nick
+            hard_excludes = kwargs.get("hard_exclude_nicks") or set()
+            candidates = [
+                offer
+                for offer in taker.orderbook_manager.offers
+                if offer.counterparty not in hard_excludes
+            ]
+            if not hard_excludes:
+                selected_offers = [
+                    offer
+                    for offer in candidates
+                    if offer.counterparty in expected_jam_nicks
+                ]
+                assert len(selected_offers) == 2, (
+                    "Expected offers from both live JAM makers"
+                )
+                initial_nicks.update(offer.counterparty for offer in selected_offers)
+            else:
+                selected_offers = [
+                    offer
+                    for offer in candidates
+                    if offer.counterparty == expected_replacement_nick
+                ]
+                assert len(selected_offers) == 1, (
+                    "Expected the live NG maker3 replacement offer"
+                )
+                replacement_nick = selected_offers[0].counterparty
+            assert len(selected_offers) == n
+            selected = {offer.counterparty: offer for offer in selected_offers}
+            total_fee = sum(
+                calculate_cj_fee(offer, cj_amount) for offer in selected.values()
+            )
+            return selected, total_fee
+
+        monkeypatch.setattr(
+            taker.orderbook_manager, "select_makers", select_interop_makers
         )
+
+        original_send = taker.directory_client.send_privmsg
+
+        async def count_send(
+            recipient: str, command: str, *args: Any, **kwargs: Any
+        ) -> str:
+            sent_messages.append((recipient, command))
+            return await original_send(recipient, command, *args, **kwargs)
+
+        monkeypatch.setattr(taker.directory_client, "send_privmsg", count_send)
+        original_auth = CoinJoinSession._phase_auth
+
+        async def stop_one_legacy_maker_then_auth(
+            session: CoinJoinSession,
+        ) -> PhaseResult:
+            nonlocal stopped_legacy
+            if not stopped_legacy:
+                failed = mixed_replacement_makers["makers"][1]
+                stop_yieldgenerator(
+                    failed["process"], failed["maker_id"], failed["wallet_name"]
+                )
+                stopped_legacy = True
+            return await original_auth(session)
+
+        monkeypatch.setattr(
+            CoinJoinSession, "_phase_auth", stop_one_legacy_maker_then_auth
+        )
+
+        txid = await taker.do_coinjoin(
+            amount=10_000_000,
+            destination=destination,
+            mixdepth=0,
+        )
+
+        assert txid is not None
+        assert replacement_nick is not None
+        failed_nicks = initial_nicks & taker.orderbook_manager.ignored_makers
+        assert len(failed_nicks) == 1
+        failed_nick = failed_nicks.pop()
+        survivor_nick = (initial_nicks - {failed_nick}).pop()
+        message_counts = Counter(sent_messages)
+
+        assert message_counts[(survivor_nick, "fill")] == 1
+        assert message_counts[(survivor_nick, "auth")] == 1
+        assert message_counts[(failed_nick, "fill")] == 1
+        assert message_counts[(failed_nick, "auth")] == 1
+        assert message_counts[(replacement_nick, "fill")] == 1
+        assert message_counts[(replacement_nick, "auth")] == 1
+        assert set(taker._session.maker_sessions) == {survivor_nick, replacement_nick}
+        assert survivor_nick not in taker.orderbook_manager.ignored_makers
+        assert replacement_nick not in taker.orderbook_manager.ignored_makers
+    finally:
+        await taker.stop()
+        await wallet.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes a regression introduced in 0.37.0 by 8af8b748.

Restoring the requested counterparty count re-invokes the whole fill or auth phase after it has already succeeded. Neither phase is incremental: `_phase_fill` allocates a fresh `CryptoSession` and sends `!fill` to every nick in `maker_sessions` with the unchanged PoDLE commitment, and `_phase_auth` sends `!auth` to every nick.

Makers reject both repeats. `ProtocolHandlersMixin._handle_fill` returns without sending any response when the commitment is already in `_reserved_commitments`, because the previous session's reservation is only released further down, after `handle_fill` succeeds. That replacement path was written for a rotated commitment (the majority blacklist case), not an unchanged one. `CoinJoinSession.handle_auth` requires state `PUBKEY_SENT`, so an already authenticated maker answers `Session not in correct state for !auth`.

Every healthy maker that completed the first round is therefore counted as failed, deleted from the session, and passed to `add_ignored_maker`, which persists to disk and is reloaded at startup. A tumbler doing sequential CoinJoins progressively and permanently blacklists the honest orderbook until it can no longer reach `minimum_makers`, and recovery needs a manual `jm-taker clear-ignored-makers`.

The default configuration makes this the normal path rather than an edge case, since `counterparty_count` defaults to a random 8 to 10 while `minimum_makers` is 4. Any maker that does not answer the first `!fill` puts the session in "successful but below target", which triggers the top-up.

Before:

```
round 1: !fill sent to 8, answered 6
round 2: !fill sent to 8, answered 2
round 3: !fill sent to 8, answered 6
round 4: !fill sent to 8, answered 2
success=False  makers=2  ignored=16
```

After:

```
round 1: !fill sent to 8, answered 6
round 2: !fill sent to 2, answered 2
success=True  makers=8  ignored=2
```

The three regression tests in `TestIncrementalPhaseTopUp` fail without the fix, and a fourth covers the control case that a fresh round still rotates the keypair. The tests added in 8af8b748 mocked the phases with `AsyncMock(side_effect=[PhaseResult(success=True), PhaseResult(success=True)])`, so the second call was assumed to succeed and preserve the existing makers, which is why CI did not catch this.
