### PR TITLE
feat(wallet): batch freeze/unfreeze UTXOs in one atomic request

### DIFF
--- a/jmwallet/src/jmwallet/wallet/service.py
+++ b/jmwallet/src/jmwallet/wallet/service.py
@@ -5,6 +5,7 @@ JoinMarket wallet service with mixdepth support.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -1136,6 +1137,33 @@ class WalletService(
                 if utxo.outpoint == outpoint:
                     utxo.frozen = False
                     return
+
+    def set_utxos_frozen(self, changes: Iterable[tuple[str, bool]]) -> None:
+        """Freeze and/or unfreeze several UTXOs in one atomic write (issue #596).
+
+        Persisting is all-or-nothing, so the in-memory cache below is only
+        reached once the whole batch is on disk.
+
+        Args:
+            changes: ``(outpoint, freeze)`` pairs in ``txid:vout`` form.
+                Mixed directions in one batch are allowed.
+
+        Raises:
+            RuntimeError: If no metadata store is available (no data_dir).
+            ValueError: If the same outpoint appears more than once.
+        """
+        if self.metadata_store is None:
+            raise RuntimeError("Cannot freeze UTXOs without a data directory")
+        items = list(changes)
+        self.metadata_store.set_frozen(items)
+        # Update the in-memory UTXO cache. Unlike the single-outpoint helpers
+        # above this cannot stop at the first hit, so index the batch instead.
+        wanted = dict(items)
+        for utxos in self.utxo_cache.values():
+            for utxo in utxos:
+                frozen = wanted.get(utxo.outpoint)
+                if frozen is not None:
+                    utxo.frozen = frozen
 
     # -- Temporary CoinJoin input locks (cross-process) ----------------------
 

--- a/jmwallet/src/jmwallet/wallet/utxo_metadata.py
+++ b/jmwallet/src/jmwallet/wallet/utxo_metadata.py
@@ -542,6 +542,45 @@ class UTXOMetadataStore:
         """
         return outpoint in self.records
 
+    def _apply_freeze(self, outpoint: str, freeze: bool, label: str | None = None) -> bool:
+        """Apply one freeze/unfreeze to the in-memory records.
+
+        The caller must already hold :meth:`_exclusive_file_lock` and have
+        called :meth:`load`; persisting with :meth:`save` is also the caller's
+        job. Factored out so the single-outpoint and batch entry points cannot
+        drift apart on the "drop the record when nothing else needs it" rule.
+
+        Returns:
+            True if ``self.records`` was changed.
+        """
+        record = self.records.get(outpoint)
+
+        if freeze:
+            if record is not None:
+                record.spendable = False
+                if label is not None and record.label is None:
+                    record.label = label
+            else:
+                self.records[outpoint] = OutputRecord(ref=outpoint, spendable=False, label=label)
+            return True
+
+        if record is None:
+            # Already unfrozen (no record means spendable)
+            return False
+
+        if (
+            record.label is not None
+            or record.lock_until is not None
+            or record.seen
+            or record.coinjoin_output
+        ):
+            # Keep the record for labels, locks, and reuse observations.
+            record.spendable = True
+        else:
+            # No other metadata -- remove entirely
+            del self.records[outpoint]
+        return True
+
     def freeze(self, outpoint: str, label: str | None = None) -> None:
         """Freeze a UTXO (set spendable to False) and persist.
 
@@ -552,12 +591,7 @@ class UTXOMetadataStore:
         """
         with self._exclusive_file_lock():
             self.load()
-            if outpoint in self.records:
-                self.records[outpoint].spendable = False
-                if label is not None and self.records[outpoint].label is None:
-                    self.records[outpoint].label = label
-            else:
-                self.records[outpoint] = OutputRecord(ref=outpoint, spendable=False, label=label)
+            self._apply_freeze(outpoint, True, label)
             self.save()
         logger.info(f"Frozen UTXO: {outpoint}")
 
@@ -572,25 +606,51 @@ class UTXOMetadataStore:
         """
         with self._exclusive_file_lock():
             self.load()
-            record = self.records.get(outpoint)
-            if record is None:
-                # Already unfrozen (no record means spendable)
+            if not self._apply_freeze(outpoint, False):
+                # Nothing on disk to change; skip the rewrite.
                 return
-
-            if (
-                record.label is not None
-                or record.lock_until is not None
-                or record.seen
-                or record.coinjoin_output
-            ):
-                # Keep the record for labels, locks, and reuse observations.
-                record.spendable = True
-            else:
-                # No other metadata -- remove entirely
-                del self.records[outpoint]
-
             self.save()
         logger.info(f"Unfrozen UTXO: {outpoint}")
+
+    def set_frozen(self, changes: Iterable[tuple[str, bool]]) -> None:
+        """Atomically apply several freeze/unfreeze changes in one write.
+
+        Mirrors :meth:`try_lock_outpoints`: the batch is validated up front and
+        then applied under a single exclusive file lock, with one ``load`` and
+        one ``save``. Either every change lands or none does, so a rejected
+        entry can never leave the batch half applied, and callers pay one
+        read-modify-write cycle instead of one per outpoint.
+
+        Args:
+            changes: ``(outpoint, freeze)`` pairs, where ``freeze=True``
+                freezes and ``False`` unfreezes. Mixed directions in one batch
+                are fine. An empty batch is a no-op and writes nothing.
+
+        Raises:
+            ValueError: If the same outpoint appears more than once. Two
+                entries for one outpoint have no well-defined result -- list
+                order alone would decide it -- so the batch is refused instead
+                of silently resolving it.
+        """
+        items = list(changes)
+        if not items:
+            return
+
+        seen: set[str] = set()
+        for outpoint, _freeze in items:
+            if outpoint in seen:
+                msg = f"Duplicate outpoint in batch: {outpoint}"
+                raise ValueError(msg)
+            seen.add(outpoint)
+
+        with self._exclusive_file_lock():
+            self.load()
+            for outpoint, freeze in items:
+                self._apply_freeze(outpoint, freeze)
+            self.save()
+
+        frozen = sum(1 for _outpoint, freeze in items if freeze)
+        logger.info(f"Batch freeze update: {frozen} frozen, {len(items) - frozen} unfrozen")
 
     def toggle_freeze(self, outpoint: str) -> bool:
         """Toggle the frozen state of a UTXO and persist.

--- a/jmwallet/src/jmwallet/wallet/utxo_metadata.py
+++ b/jmwallet/src/jmwallet/wallet/utxo_metadata.py
@@ -34,6 +34,7 @@ Reference: https://github.com/bitcoin/bips/blob/master/bip-0329.mediawiki
 
 from __future__ import annotations
 
+import copy
 import json
 import math
 import tempfile
@@ -667,9 +668,18 @@ class UTXOMetadataStore:
 
         with self._exclusive_file_lock():
             self.load()
+            # Snapshot before mutating so a save() failure can roll the
+            # in-memory state back to what is actually on disk, instead of
+            # leaving self.records reporting a batch that was never
+            # persisted.
+            before = copy.deepcopy(self.records)
             for outpoint, freeze in items:
                 self._apply_freeze(outpoint, freeze)
-            self.save()
+            try:
+                self.save()
+            except Exception:
+                self.records = before
+                raise
 
         frozen = sum(1 for _outpoint, freeze in items if freeze)
         logger.info(f"Batch freeze update: {frozen} frozen, {len(items) - frozen} unfrozen")

--- a/jmwallet/src/jmwallet/wallet/utxo_metadata.py
+++ b/jmwallet/src/jmwallet/wallet/utxo_metadata.py
@@ -102,6 +102,27 @@ def _validate_lock_ttl(ttl: float) -> float:
     return validated
 
 
+def _normalize_outpoint_for_dedup(outpoint: str) -> str | tuple[str, int]:
+    """Return a case/padding-independent identity for a ``txid:vout`` string.
+
+    Two outpoint strings that differ only in txid case or vout zero-padding
+    (``"AB..:0"`` vs. ``"ab..:00"``) name the same UTXO but never compare
+    equal as raw strings, which lets a naive string-based duplicate check let
+    both through. Callers of :meth:`UTXOMetadataStore.set_frozen` are expected
+    to pass well-formed outpoints (the HTTP layer validates this before the
+    store ever sees them); a malformed string falls back to raw-string
+    identity rather than raising here, since format validation is not this
+    method's job.
+    """
+    txid, sep, vout = outpoint.partition(":")
+    if not sep:
+        return outpoint
+    try:
+        return txid.lower(), int(vout)
+    except ValueError:
+        return outpoint
+
+
 @dataclass
 class OutputRecord:
     """A BIP-329 output record for UTXO metadata.
@@ -636,12 +657,13 @@ class UTXOMetadataStore:
         if not items:
             return
 
-        seen: set[str] = set()
+        seen: set[str | tuple[str, int]] = set()
         for outpoint, _freeze in items:
-            if outpoint in seen:
+            key = _normalize_outpoint_for_dedup(outpoint)
+            if key in seen:
                 msg = f"Duplicate outpoint in batch: {outpoint}"
                 raise ValueError(msg)
-            seen.add(outpoint)
+            seen.add(key)
 
         with self._exclusive_file_lock():
             self.load()

--- a/jmwallet/tests/test_utxo_metadata.py
+++ b/jmwallet/tests/test_utxo_metadata.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
 
 import pytest
 
@@ -1407,3 +1408,106 @@ class TestCoinJoinLocks:
 
         store = UTXOMetadataStore(path=store_path)
         assert store.try_lock_outpoints([a], ttl=MAX_COINJOIN_LOCK_TTL, owner="session-a")
+
+
+class TestBatchFreeze:
+    """Tests for atomic batched freeze/unfreeze (issue #596)."""
+
+    @pytest.fixture
+    def store_path(self, tmp_path):
+        return tmp_path / "wallet_metadata.jsonl"
+
+    @pytest.fixture
+    def store(self, store_path):
+        return UTXOMetadataStore(path=store_path)
+
+    @pytest.fixture
+    def a(self):
+        return "aa" * 32 + ":0"
+
+    @pytest.fixture
+    def b(self):
+        return "bb" * 32 + ":1"
+
+    @pytest.fixture
+    def c(self):
+        return "cc" * 32 + ":2"
+
+    def test_mixed_batch_applies_both_directions(self, store, a, b, c):
+        """One call can freeze some outpoints and unfreeze others."""
+        store.freeze(b)
+        store.freeze(c)
+
+        store.set_frozen([(a, True), (b, False), (c, True)])
+
+        assert store.is_frozen(a)
+        assert not store.is_frozen(b)
+        assert store.is_frozen(c)
+
+    def test_batch_persists(self, store, a, b):
+        """A batch is written to disk, not just held in memory."""
+        store.set_frozen([(a, True), (b, True)])
+
+        reloaded = UTXOMetadataStore(path=store.path)
+        reloaded.load()
+        assert reloaded.is_frozen(a)
+        assert reloaded.is_frozen(b)
+
+    def test_empty_batch_writes_nothing(self, store, store_path):
+        """An empty batch is a no-op and must not touch the file."""
+        store.set_frozen([])
+        assert not store_path.exists()
+
+    def test_duplicate_outpoint_raises(self, store, a):
+        """Two entries for one outpoint have no defined outcome, so refuse."""
+        with pytest.raises(ValueError, match="Duplicate outpoint"):
+            store.set_frozen([(a, True), (a, False)])
+
+    def test_duplicate_outpoint_applies_nothing(self, store, a, b, store_path):
+        """A rejected batch must not partially apply."""
+        with pytest.raises(ValueError, match="Duplicate outpoint"):
+            store.set_frozen([(b, True), (a, True), (a, False)])
+
+        assert not store_path.exists()
+        assert not store.is_frozen(a)
+        assert not store.is_frozen(b)
+
+    def test_batch_unfreeze_drops_bare_record(self, store, a):
+        """Batch unfreeze matches unfreeze(): a record with nothing else goes away."""
+        store.freeze(a)
+        store.set_frozen([(a, False)])
+
+        assert not store.is_frozen(a)
+        assert a not in store.records
+
+    def test_batch_unfreeze_keeps_labelled_record(self, store, a):
+        """A label must survive a batch unfreeze, same as the single-outpoint path."""
+        store.freeze(a, label="cj-out")
+        store.set_frozen([(a, False)])
+
+        assert not store.is_frozen(a)
+        assert store.records[a].label == "cj-out"
+
+    def test_batch_writes_once(self, store, a, b, c):
+        """The whole batch costs one read-modify-write, not one per outpoint."""
+        with patch.object(
+            UTXOMetadataStore, "save", autospec=True, side_effect=UTXOMetadataStore.save
+        ) as spy:
+            store.set_frozen([(a, True), (b, True), (c, True)])
+
+        assert spy.call_count == 1
+
+    def test_failed_save_leaves_disk_untouched(self, store, a, b, store_path):
+        """If persisting fails the batch must not be half applied on disk."""
+        store.freeze(a)
+
+        with (
+            patch.object(UTXOMetadataStore, "save", side_effect=OSError("disk full")),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            store.set_frozen([(a, False), (b, True)])
+
+        reloaded = UTXOMetadataStore(path=store_path)
+        reloaded.load()
+        assert reloaded.is_frozen(a)
+        assert not reloaded.is_frozen(b)

--- a/jmwallet/tests/test_utxo_metadata.py
+++ b/jmwallet/tests/test_utxo_metadata.py
@@ -1463,6 +1463,13 @@ class TestBatchFreeze:
         with pytest.raises(ValueError, match="Duplicate outpoint"):
             store.set_frozen([(a, True), (a, False)])
 
+    def test_duplicate_outpoint_different_case_and_padding_raises(self, store):
+        """A raw-string check would miss this; same UTXO, different formatting."""
+        upper = "AA" * 32 + ":0"
+        padded = "aa" * 32 + ":00"
+        with pytest.raises(ValueError, match="Duplicate outpoint"):
+            store.set_frozen([(upper, True), (padded, False)])
+
     def test_duplicate_outpoint_applies_nothing(self, store, a, b, store_path):
         """A rejected batch must not partially apply."""
         with pytest.raises(ValueError, match="Duplicate outpoint"):

--- a/jmwallet/tests/test_utxo_metadata.py
+++ b/jmwallet/tests/test_utxo_metadata.py
@@ -1518,3 +1518,19 @@ class TestBatchFreeze:
         reloaded.load()
         assert reloaded.is_frozen(a)
         assert not reloaded.is_frozen(b)
+
+    def test_failed_save_restores_in_memory_records(self, store, a, b):
+        """A save() failure must not leave the same store object's in-memory
+        records reporting a batch that was never actually persisted -- a
+        caller checking is_frozen() right after the failed call should still
+        see the pre-batch state, not the mutated-but-unsaved one."""
+        store.freeze(a)
+
+        with (
+            patch.object(UTXOMetadataStore, "save", side_effect=OSError("disk full")),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            store.set_frozen([(a, False), (b, True)])
+
+        assert store.is_frozen(a)
+        assert not store.is_frozen(b)

--- a/jmwallet/tests/test_utxo_selection.py
+++ b/jmwallet/tests/test_utxo_selection.py
@@ -1977,3 +1977,61 @@ class TestApplyFrozenStateHotReload:
         # Should not raise
         ws._apply_frozen_state()
         assert not ws.utxo_cache[0][0].frozen
+
+
+class TestSetUtxosFrozen:
+    """WalletService.set_utxos_frozen: batched freeze/unfreeze (issue #596)."""
+
+    def _attach_store(self, ws, tmp_path):
+        from jmwallet.wallet.utxo_metadata import UTXOMetadataStore
+
+        ws.metadata_store = UTXOMetadataStore(path=tmp_path / "wallet_metadata.jsonl")
+        ws.metadata_store.load()
+
+    def test_updates_cache_in_both_directions(self, wallet_service, tmp_path):
+        self._attach_store(wallet_service, tmp_path)
+        a = "a" * 64 + ":0"
+        b = "b" * 64 + ":0"
+        wallet_service.freeze_utxo(b)
+
+        wallet_service.set_utxos_frozen([(a, True), (b, False)])
+
+        by_outpoint = {u.outpoint: u for u in wallet_service.utxo_cache[0]}
+        assert by_outpoint[a].frozen is True
+        assert by_outpoint[b].frozen is False
+
+    def test_updates_every_match_not_just_the_first(self, wallet_service, tmp_path):
+        """The single-outpoint helpers return at the first hit; a batch cannot."""
+        self._attach_store(wallet_service, tmp_path)
+        cached = [u for utxos in wallet_service.utxo_cache.values() for u in utxos]
+        outpoints = [u.outpoint for u in cached]
+        assert len(outpoints) > 1, "fixture should cache more than one UTXO"
+
+        wallet_service.set_utxos_frozen([(op, True) for op in outpoints])
+
+        assert all(u.frozen for u in cached)
+
+    def test_persists_through_the_store(self, wallet_service, tmp_path):
+        from jmwallet.wallet.utxo_metadata import UTXOMetadataStore
+
+        self._attach_store(wallet_service, tmp_path)
+        a = "a" * 64 + ":0"
+
+        wallet_service.set_utxos_frozen([(a, True)])
+
+        reloaded = UTXOMetadataStore(path=tmp_path / "wallet_metadata.jsonl")
+        reloaded.load()
+        assert reloaded.is_frozen(a)
+
+    def test_duplicate_outpoint_raises(self, wallet_service, tmp_path):
+        self._attach_store(wallet_service, tmp_path)
+        a = "a" * 64 + ":0"
+
+        with pytest.raises(ValueError, match="Duplicate outpoint"):
+            wallet_service.set_utxos_frozen([(a, True), (a, False)])
+
+    def test_without_store_raises(self, wallet_service):
+        wallet_service.metadata_store = None
+
+        with pytest.raises(RuntimeError, match="without a data directory"):
+            wallet_service.set_utxos_frozen([("a" * 64 + ":0", True)])

--- a/jmwalletd/src/jmwalletd/models.py
+++ b/jmwalletd/src/jmwalletd/models.py
@@ -523,6 +523,33 @@ class FreezeRequest(BaseModel):
     model_config = {"populate_by_name": True}
 
 
+class FreezeBatchEntry(BaseModel):
+    """One entry of a POST /api/v1/wallet/{walletname}/freeze-batch request.
+
+    Same field name and hyphenated wire alias as :class:`FreezeRequest`, so a
+    caller migrating from one-at-a-time calls to a batch just wraps the same
+    entries in a list.
+    """
+
+    utxo_string: str = Field(alias="utxo-string")
+    freeze: bool
+
+    model_config = {"populate_by_name": True}
+
+
+class FreezeBatchRequest(BaseModel):
+    """POST /api/v1/wallet/{walletname}/freeze-batch request (issue #596).
+
+    Applies every entry atomically: either the whole batch lands or, if any
+    entry is invalid, none of it does. An empty list and a repeated outpoint
+    are both rejected outright rather than treated as a partial no-op, since
+    a duplicate has no well-defined outcome (list order alone would decide
+    it) and an empty list is more likely a client bug than "no preference".
+    """
+
+    entries: list[FreezeBatchEntry] = Field(..., min_length=1, max_length=500)
+
+
 # ---------------------------------------------------------------------------
 # Sign message
 # ---------------------------------------------------------------------------

--- a/jmwalletd/src/jmwalletd/routers/wallet_data.py
+++ b/jmwalletd/src/jmwalletd/routers/wallet_data.py
@@ -384,6 +384,19 @@ def _validate_outpoint_format(utxo_str: str) -> None:
         raise InvalidRequestFormat(f"Invalid vout in UTXO: {utxo_str}") from exc
 
 
+def _normalized_outpoint_key(utxo_str: str) -> tuple[str, int]:
+    """Return an outpoint's ``(txid, vout)`` identity, independent of formatting.
+
+    Callers must run :func:`_validate_outpoint_format` first. Two outpoint
+    strings that only differ in txid case or vout zero-padding (e.g.
+    ``"AB..:0"`` vs. ``"ab..:00"``) refer to the same UTXO but never equal
+    each other as raw strings -- which lets a naive string-based duplicate
+    check miss them and let both through.
+    """
+    txid, vout = utxo_str.split(":")
+    return txid.lower(), int(vout)
+
+
 # ---------------------------------------------------------------------------
 # POST /api/v1/wallet/{walletname}/freeze
 # ---------------------------------------------------------------------------
@@ -434,11 +447,12 @@ async def freeze_utxos_batch(
     for entry in body.entries:
         _validate_outpoint_format(entry.utxo_string)
 
-    seen: set[str] = set()
+    seen: set[tuple[str, int]] = set()
     for entry in body.entries:
-        if entry.utxo_string in seen:
+        key = _normalized_outpoint_key(entry.utxo_string)
+        if key in seen:
             raise InvalidRequestFormat(f"Duplicate UTXO in batch: {entry.utxo_string}")
-        seen.add(entry.utxo_string)
+        seen.add(key)
 
     ws = state.wallet_service
     try:

--- a/jmwalletd/src/jmwalletd/routers/wallet_data.py
+++ b/jmwalletd/src/jmwalletd/routers/wallet_data.py
@@ -10,6 +10,7 @@ from typing import Any
 from fastapi import APIRouter, Depends
 from loguru import logger
 
+from jmcore.protocol import UTXOMetadata
 from jmwallet.history import get_address_history_types, get_used_addresses
 from jmwallet.wallet.bond_registry import create_bond_info, load_registry, save_registry
 from jmwallet.wallet.constants import FIDELITY_BOND_BRANCH
@@ -387,12 +388,19 @@ def _validate_outpoint_format(utxo_str: str) -> None:
 def _validate_and_normalize_outpoint(utxo_str: str) -> tuple[str, int]:
     """Validate a ``txid:vout`` string and return its canonical identity.
 
-    Stricter than :func:`_validate_outpoint_format`: the txid must be exactly
-    64 hex characters and the vout a non-negative integer. Returns
-    ``(lowercase_txid, vout)`` so callers can both deduplicate and build the
-    same canonical ``"txid:vout"`` string the wallet's UTXO cache and
-    metadata store use as their key (lowercase txid, unpadded vout).
-    Freeze-batch uses this instead of the looser single-UTXO check because a
+    Stricter than :func:`_validate_outpoint_format`, and reuses
+    :class:`jmcore.protocol.UTXOMetadata`'s validation (the same contract the
+    rest of the protocol enforces) instead of a parallel, weaker
+    reimplementation: the txid must be exactly 64 hex characters -- checked
+    with ``binascii.unhexlify``, which (unlike ``bytes.fromhex``) rejects
+    embedded whitespace, so a 64-character string that is actually fewer than
+    32 real bytes padded with spaces is caught -- and the vout must fit the
+    Bitcoin uint32 range (``0`` to ``0xFFFFFFFF``).
+
+    Returns ``(lowercase_txid, vout)`` so callers can both deduplicate and
+    build the same canonical ``"txid:vout"`` string the wallet's UTXO cache
+    and metadata store use as their key. Freeze-batch normalizes to this
+    before applying (not just for duplicate detection), because a
     wrongly-cased or zero-padded outpoint would otherwise be accepted,
     written to the metadata store under that literal key, and return success
     -- without ever touching the real cached UTXO, which is keyed by the
@@ -403,19 +411,15 @@ def _validate_and_normalize_outpoint(utxo_str: str) -> tuple[str, int]:
         raise InvalidRequestFormat(f"Invalid UTXO format: {utxo_str}. Expected txid:vout.")
 
     txid, vout_str = parts
-    if len(txid) != 64:
-        raise InvalidRequestFormat(f"Invalid txid in UTXO: {utxo_str}. Expected 64 hex characters.")
-    try:
-        bytes.fromhex(txid)
-    except ValueError as exc:
-        raise InvalidRequestFormat(f"Invalid txid in UTXO: {utxo_str}. Expected hex.") from exc
-
     try:
         vout = int(vout_str)
     except ValueError as exc:
         raise InvalidRequestFormat(f"Invalid vout in UTXO: {utxo_str}") from exc
-    if vout < 0:
-        raise InvalidRequestFormat(f"Invalid vout in UTXO: {utxo_str}. Must not be negative.")
+
+    try:
+        UTXOMetadata(txid=txid, vout=vout)
+    except ValueError as exc:
+        raise InvalidRequestFormat(f"Invalid UTXO {utxo_str}: {exc}") from exc
 
     return txid.lower(), vout
 

--- a/jmwalletd/src/jmwalletd/routers/wallet_data.py
+++ b/jmwalletd/src/jmwalletd/routers/wallet_data.py
@@ -384,17 +384,40 @@ def _validate_outpoint_format(utxo_str: str) -> None:
         raise InvalidRequestFormat(f"Invalid vout in UTXO: {utxo_str}") from exc
 
 
-def _normalized_outpoint_key(utxo_str: str) -> tuple[str, int]:
-    """Return an outpoint's ``(txid, vout)`` identity, independent of formatting.
+def _validate_and_normalize_outpoint(utxo_str: str) -> tuple[str, int]:
+    """Validate a ``txid:vout`` string and return its canonical identity.
 
-    Callers must run :func:`_validate_outpoint_format` first. Two outpoint
-    strings that only differ in txid case or vout zero-padding (e.g.
-    ``"AB..:0"`` vs. ``"ab..:00"``) refer to the same UTXO but never equal
-    each other as raw strings -- which lets a naive string-based duplicate
-    check miss them and let both through.
+    Stricter than :func:`_validate_outpoint_format`: the txid must be exactly
+    64 hex characters and the vout a non-negative integer. Returns
+    ``(lowercase_txid, vout)`` so callers can both deduplicate and build the
+    same canonical ``"txid:vout"`` string the wallet's UTXO cache and
+    metadata store use as their key (lowercase txid, unpadded vout).
+    Freeze-batch uses this instead of the looser single-UTXO check because a
+    wrongly-cased or zero-padded outpoint would otherwise be accepted,
+    written to the metadata store under that literal key, and return success
+    -- without ever touching the real cached UTXO, which is keyed by the
+    canonical form.
     """
-    txid, vout = utxo_str.split(":")
-    return txid.lower(), int(vout)
+    parts = utxo_str.split(":")
+    if len(parts) != 2:
+        raise InvalidRequestFormat(f"Invalid UTXO format: {utxo_str}. Expected txid:vout.")
+
+    txid, vout_str = parts
+    if len(txid) != 64:
+        raise InvalidRequestFormat(f"Invalid txid in UTXO: {utxo_str}. Expected 64 hex characters.")
+    try:
+        bytes.fromhex(txid)
+    except ValueError as exc:
+        raise InvalidRequestFormat(f"Invalid txid in UTXO: {utxo_str}. Expected hex.") from exc
+
+    try:
+        vout = int(vout_str)
+    except ValueError as exc:
+        raise InvalidRequestFormat(f"Invalid vout in UTXO: {utxo_str}") from exc
+    if vout < 0:
+        raise InvalidRequestFormat(f"Invalid vout in UTXO: {utxo_str}. Must not be negative.")
+
+    return txid.lower(), vout
 
 
 # ---------------------------------------------------------------------------
@@ -444,19 +467,23 @@ async def freeze_utxos_batch(
     if state.taker_running:
         raise ActionNotAllowed("Cannot freeze/unfreeze UTXOs while a coinjoin is in progress.")
 
-    for entry in body.entries:
-        _validate_outpoint_format(entry.utxo_string)
-
+    # Validate, dedupe, and canonicalize in one pass: normalizing here (rather
+    # than deferring to the store) means the outpoint actually applied is the
+    # same string the wallet's UTXO cache and metadata store already key on,
+    # so a wrongly-cased or zero-padded request can't silently freeze nothing
+    # while still reporting success.
     seen: set[tuple[str, int]] = set()
+    normalized_entries: list[tuple[str, bool]] = []
     for entry in body.entries:
-        key = _normalized_outpoint_key(entry.utxo_string)
-        if key in seen:
+        txid, vout = _validate_and_normalize_outpoint(entry.utxo_string)
+        if (txid, vout) in seen:
             raise InvalidRequestFormat(f"Duplicate UTXO in batch: {entry.utxo_string}")
-        seen.add(key)
+        seen.add((txid, vout))
+        normalized_entries.append((f"{txid}:{vout}", entry.freeze))
 
     ws = state.wallet_service
     try:
-        ws.set_utxos_frozen((entry.utxo_string, entry.freeze) for entry in body.entries)
+        ws.set_utxos_frozen(normalized_entries)
     except ValueError as exc:
         # Belt-and-braces: the store re-checks duplicates itself, so this
         # should be unreachable given the pre-check above.

--- a/jmwalletd/src/jmwalletd/routers/wallet_data.py
+++ b/jmwalletd/src/jmwalletd/routers/wallet_data.py
@@ -25,6 +25,7 @@ from jmwalletd.models import (
     ConfigGetRequest,
     ConfigGetResponse,
     ConfigSetRequest,
+    FreezeBatchRequest,
     FreezeRequest,
     GetAddressResponse,
     GetSeedResponse,
@@ -371,6 +372,18 @@ async def get_seed(
     return GetSeedResponse(seedphrase=state.wallet_mnemonic)
 
 
+def _validate_outpoint_format(utxo_str: str) -> None:
+    """Validate a ``txid:vout`` string, raising :class:`InvalidRequestFormat` on failure."""
+    parts = utxo_str.split(":")
+    if len(parts) != 2:
+        raise InvalidRequestFormat(f"Invalid UTXO format: {utxo_str}. Expected txid:vout.")
+
+    try:
+        int(parts[1])
+    except ValueError as exc:
+        raise InvalidRequestFormat(f"Invalid vout in UTXO: {utxo_str}") from exc
+
+
 # ---------------------------------------------------------------------------
 # POST /api/v1/wallet/{walletname}/freeze
 # ---------------------------------------------------------------------------
@@ -386,22 +399,54 @@ async def freeze_utxo(
     if state.taker_running:
         raise ActionNotAllowed("Cannot freeze/unfreeze UTXOs while a coinjoin is in progress.")
 
-    # Validate utxo format: "txid:vout"
     utxo_str = body.utxo_string
-    parts = utxo_str.split(":")
-    if len(parts) != 2:
-        raise InvalidRequestFormat(f"Invalid UTXO format: {utxo_str}. Expected txid:vout.")
-
-    try:
-        int(parts[1])
-    except ValueError as exc:
-        raise InvalidRequestFormat(f"Invalid vout in UTXO: {utxo_str}") from exc
+    _validate_outpoint_format(utxo_str)
 
     ws = state.wallet_service
     if body.freeze:
         ws.freeze_utxo(utxo_str)
     else:
         ws.unfreeze_utxo(utxo_str)
+
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/wallet/{walletname}/freeze-batch
+# ---------------------------------------------------------------------------
+@router.post("/wallet/{walletname}/freeze-batch", operation_id="freezebatch")
+async def freeze_utxos_batch(
+    walletname: str,
+    body: FreezeBatchRequest,
+    _auth: dict[str, Any] = Depends(require_auth),
+    _wallet: None = Depends(require_wallet_match),
+    state: DaemonState = Depends(get_daemon_state),
+) -> dict[str, str]:
+    """Freeze and/or unfreeze several UTXOs in one atomic request (issue #596).
+
+    Mixed directions are allowed in the same batch. Every entry is validated
+    before anything is written; if any outpoint is malformed or repeated, the
+    whole request is rejected and nothing on disk changes.
+    """
+    if state.taker_running:
+        raise ActionNotAllowed("Cannot freeze/unfreeze UTXOs while a coinjoin is in progress.")
+
+    for entry in body.entries:
+        _validate_outpoint_format(entry.utxo_string)
+
+    seen: set[str] = set()
+    for entry in body.entries:
+        if entry.utxo_string in seen:
+            raise InvalidRequestFormat(f"Duplicate UTXO in batch: {entry.utxo_string}")
+        seen.add(entry.utxo_string)
+
+    ws = state.wallet_service
+    try:
+        ws.set_utxos_frozen((entry.utxo_string, entry.freeze) for entry in body.entries)
+    except ValueError as exc:
+        # Belt-and-braces: the store re-checks duplicates itself, so this
+        # should be unreachable given the pre-check above.
+        raise InvalidRequestFormat(str(exc)) from exc
 
     return {}
 

--- a/jmwalletd/tests/test_idor_wallet_name.py
+++ b/jmwalletd/tests/test_idor_wallet_name.py
@@ -181,6 +181,31 @@ class TestIDORFreeze:
         assert resp.status_code != 404
 
 
+class TestIDORFreezeBatch:
+    """POST /api/v1/wallet/{walletname}/freeze-batch"""
+
+    def test_idor_wrong_name_rejected(self, app_with_wallet: TestClient, auth_token: str) -> None:
+        resp = app_with_wallet.post(
+            f"/api/v1/wallet/{EVIL_WALLET}/freeze-batch",
+            headers=_auth(auth_token),
+            json={"entries": [{"utxo-string": "aa" * 32 + ":0", "freeze": True}]},
+        )
+        assert resp.status_code == 404, (
+            f"IDOR: freeze-batch returned {resp.status_code} for '{EVIL_WALLET}'"
+        )
+
+    def test_correct_walletname_any_response(
+        self, app_with_wallet: TestClient, auth_token: str
+    ) -> None:
+        """Just confirm the request is not blocked by wallet-name check."""
+        resp = app_with_wallet.post(
+            f"/api/v1/wallet/{REAL_WALLET}/freeze-batch",
+            headers=_auth(auth_token),
+            json={"entries": [{"utxo-string": "aa" * 32 + ":0", "freeze": True}]},
+        )
+        assert resp.status_code != 404
+
+
 class TestIDORDirectSend:
     """POST /api/v1/wallet/{walletname}/taker/direct-send"""
 

--- a/jmwalletd/tests/test_openapi_operation_ids.py
+++ b/jmwalletd/tests/test_openapi_operation_ids.py
@@ -39,6 +39,7 @@ EXPECTED_OPERATION_IDS: dict[tuple[str, str], str] = {
     ): "gettimelockaddress",
     ("get", "/api/v1/wallet/{walletname}/getseed"): "getseed",
     ("post", "/api/v1/wallet/{walletname}/freeze"): "freeze",
+    ("post", "/api/v1/wallet/{walletname}/freeze-batch"): "freezebatch",
     ("post", "/api/v1/wallet/{walletname}/configget"): "configget",
     ("post", "/api/v1/wallet/{walletname}/configset"): "configsetting",
     (

--- a/jmwalletd/tests/test_wallet_data_router.py
+++ b/jmwalletd/tests/test_wallet_data_router.py
@@ -553,6 +553,57 @@ class TestFreezeBatch:
         assert resp.status_code == 400
         ws.set_utxos_frozen.assert_not_called()
 
+    def test_whitespace_padded_txid_is_rejected(
+        self, authed_client: tuple[TestClient, str]
+    ) -> None:
+        """64 characters but only 62 are real hex -- bytes.fromhex() tolerates the
+        embedded spaces and would silently accept this as a 31-byte txid."""
+        client, token = authed_client
+        state = get_daemon_state()
+        ws = state.wallet_service
+        ws.set_utxos_frozen = Mock()
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/freeze-batch",
+            json={"entries": [{"utxo-string": "aa" * 31 + "  " + ":0", "freeze": True}]},
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 400
+        ws.set_utxos_frozen.assert_not_called()
+
+    def test_vout_above_uint32_max_is_rejected(self, authed_client: tuple[TestClient, str]) -> None:
+        """vout must fit Bitcoin's uint32 range; 0xFFFFFFFF + 1 overflows it."""
+        client, token = authed_client
+        state = get_daemon_state()
+        ws = state.wallet_service
+        ws.set_utxos_frozen = Mock()
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/freeze-batch",
+            json={"entries": [{"utxo-string": "aa" * 32 + ":4294967296", "freeze": True}]},
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 400
+        ws.set_utxos_frozen.assert_not_called()
+
+    def test_vout_at_uint32_max_is_accepted(self, authed_client: tuple[TestClient, str]) -> None:
+        """0xFFFFFFFF itself is the boundary and must still be valid."""
+        client, token = authed_client
+        state = get_daemon_state()
+        ws = state.wallet_service
+        ws.set_utxos_frozen = Mock()
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/freeze-batch",
+            json={"entries": [{"utxo-string": "aa" * 32 + ":4294967295", "freeze": True}]},
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 200
+        ws.set_utxos_frozen.assert_called_once()
+
     def test_uppercase_and_padded_outpoint_is_normalized_before_applying(
         self, authed_client: tuple[TestClient, str]
     ) -> None:

--- a/jmwalletd/tests/test_wallet_data_router.py
+++ b/jmwalletd/tests/test_wallet_data_router.py
@@ -508,6 +508,71 @@ class TestFreezeBatch:
         assert resp.status_code == 400
         ws.set_utxos_frozen.assert_not_called()
 
+    def test_non_hex_txid_is_rejected(self, authed_client: tuple[TestClient, str]) -> None:
+        client, token = authed_client
+        state = get_daemon_state()
+        ws = state.wallet_service
+        ws.set_utxos_frozen = Mock()
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/freeze-batch",
+            json={"entries": [{"utxo-string": "zz" * 32 + ":0", "freeze": True}]},
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 400
+        ws.set_utxos_frozen.assert_not_called()
+
+    def test_wrong_length_txid_is_rejected(self, authed_client: tuple[TestClient, str]) -> None:
+        client, token = authed_client
+        state = get_daemon_state()
+        ws = state.wallet_service
+        ws.set_utxos_frozen = Mock()
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/freeze-batch",
+            json={"entries": [{"utxo-string": "aa" * 31 + ":0", "freeze": True}]},
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 400
+        ws.set_utxos_frozen.assert_not_called()
+
+    def test_negative_vout_is_rejected(self, authed_client: tuple[TestClient, str]) -> None:
+        client, token = authed_client
+        state = get_daemon_state()
+        ws = state.wallet_service
+        ws.set_utxos_frozen = Mock()
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/freeze-batch",
+            json={"entries": [{"utxo-string": "aa" * 32 + ":-1", "freeze": True}]},
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 400
+        ws.set_utxos_frozen.assert_not_called()
+
+    def test_uppercase_and_padded_outpoint_is_normalized_before_applying(
+        self, authed_client: tuple[TestClient, str]
+    ) -> None:
+        """A wrongly-cased/padded outpoint must still hit the canonical cached UTXO,
+        not silently no-op under its raw key while the endpoint reports success."""
+        client, token = authed_client
+        state = get_daemon_state()
+        ws = state.wallet_service
+        ws.set_utxos_frozen = Mock()
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/freeze-batch",
+            json={"entries": [{"utxo-string": "AA" * 32 + ":00", "freeze": True}]},
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 200
+        ((changes,), _kwargs) = ws.set_utxos_frozen.call_args
+        assert list(changes) == [("aa" * 32 + ":0", True)]
+
     def test_rejects_while_coinjoin_running(self, authed_client: tuple[TestClient, str]) -> None:
         client, token = authed_client
         state = get_daemon_state()

--- a/jmwalletd/tests/test_wallet_data_router.py
+++ b/jmwalletd/tests/test_wallet_data_router.py
@@ -469,6 +469,30 @@ class TestFreezeBatch:
         assert "Duplicate" in resp.json()["message"]
         ws.set_utxos_frozen.assert_not_called()
 
+    def test_duplicate_outpoint_with_different_case_and_padding_is_rejected(
+        self, authed_client: tuple[TestClient, str]
+    ) -> None:
+        """A raw-string dedup would miss this: same UTXO, different formatting."""
+        client, token = authed_client
+        state = get_daemon_state()
+        ws = state.wallet_service
+        ws.set_utxos_frozen = Mock()
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/freeze-batch",
+            json={
+                "entries": [
+                    {"utxo-string": "AA" * 32 + ":0", "freeze": True},
+                    {"utxo-string": "aa" * 32 + ":00", "freeze": False},
+                ]
+            },
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 400
+        assert "Duplicate" in resp.json()["message"]
+        ws.set_utxos_frozen.assert_not_called()
+
     def test_malformed_outpoint_is_rejected(self, authed_client: tuple[TestClient, str]) -> None:
         client, token = authed_client
         state = get_daemon_state()

--- a/jmwalletd/tests/test_wallet_data_router.py
+++ b/jmwalletd/tests/test_wallet_data_router.py
@@ -395,6 +395,128 @@ class TestFreeze:
         ws.unfreeze_utxo.assert_called_once_with("abc123:0")
 
 
+class TestFreezeBatch:
+    """POST /freeze-batch — atomic batched freeze/unfreeze (issue #596)."""
+
+    def test_requires_auth(self, authed_client: tuple[TestClient, str]) -> None:
+        client, _ = authed_client
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/freeze-batch",
+            json={"entries": [{"utxo-string": "abc:0", "freeze": True}]},
+        )
+        assert resp.status_code == 401
+
+    def test_mixed_batch_forwards_pairs_in_order(
+        self, authed_client: tuple[TestClient, str]
+    ) -> None:
+        client, token = authed_client
+        state = get_daemon_state()
+        ws = state.wallet_service
+        ws.set_utxos_frozen = Mock()
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/freeze-batch",
+            json={
+                "entries": [
+                    {"utxo-string": "aa" * 32 + ":0", "freeze": True},
+                    {"utxo-string": "bb" * 32 + ":1", "freeze": False},
+                ]
+            },
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 200
+        ((changes,), _kwargs) = ws.set_utxos_frozen.call_args
+        assert list(changes) == [
+            ("aa" * 32 + ":0", True),
+            ("bb" * 32 + ":1", False),
+        ]
+
+    def test_empty_batch_is_rejected(self, authed_client: tuple[TestClient, str]) -> None:
+        client, token = authed_client
+        state = get_daemon_state()
+        ws = state.wallet_service
+        ws.set_utxos_frozen = Mock()
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/freeze-batch",
+            json={"entries": []},
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 422
+        ws.set_utxos_frozen.assert_not_called()
+
+    def test_duplicate_outpoint_is_rejected(self, authed_client: tuple[TestClient, str]) -> None:
+        client, token = authed_client
+        state = get_daemon_state()
+        ws = state.wallet_service
+        ws.set_utxos_frozen = Mock()
+        outpoint = "aa" * 32 + ":0"
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/freeze-batch",
+            json={
+                "entries": [
+                    {"utxo-string": outpoint, "freeze": True},
+                    {"utxo-string": outpoint, "freeze": False},
+                ]
+            },
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 400
+        assert "Duplicate" in resp.json()["message"]
+        ws.set_utxos_frozen.assert_not_called()
+
+    def test_malformed_outpoint_is_rejected(self, authed_client: tuple[TestClient, str]) -> None:
+        client, token = authed_client
+        state = get_daemon_state()
+        ws = state.wallet_service
+        ws.set_utxos_frozen = Mock()
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/freeze-batch",
+            json={"entries": [{"utxo-string": "not-an-outpoint", "freeze": True}]},
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 400
+        ws.set_utxos_frozen.assert_not_called()
+
+    def test_rejects_while_coinjoin_running(self, authed_client: tuple[TestClient, str]) -> None:
+        client, token = authed_client
+        state = get_daemon_state()
+        state.taker_running = True
+        ws = state.wallet_service
+        ws.set_utxos_frozen = Mock()
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/freeze-batch",
+            json={"entries": [{"utxo-string": "aa" * 32 + ":0", "freeze": True}]},
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 400
+        ws.set_utxos_frozen.assert_not_called()
+
+    def test_batch_size_cap_is_enforced(self, authed_client: tuple[TestClient, str]) -> None:
+        client, token = authed_client
+        state = get_daemon_state()
+        ws = state.wallet_service
+        ws.set_utxos_frozen = Mock()
+        entries = [{"utxo-string": f"{i:064x}:0", "freeze": True} for i in range(501)]
+
+        resp = client.post(
+            "/api/v1/wallet/test_wallet.jmdat/freeze-batch",
+            json={"entries": entries},
+            headers=_auth_headers(token),
+        )
+
+        assert resp.status_code == 422
+        ws.set_utxos_frozen.assert_not_called()
+
+
 class TestConfigGet:
     def test_requires_auth(self, authed_client: tuple[TestClient, str]) -> None:
         client, _ = authed_client


### PR DESCRIPTION
closes #596

two commits:

- store layer: `UTXOMetadataStore.set_frozen()` applies a list of (outpoint, freeze) pairs under one exclusive lock, one load, one save. same shape as `try_lock_outpoints` - validates everything first, then applies, so a bad entry never leaves it half done. `WalletService.set_utxos_frozen()` wraps it and updates the in-memory cache.
- endpoint: new `POST /freeze-batch`, seperate from the existing `/freeze` so nothing breaks. mixed freeze/unfreeze in one call, empty list -> 422, duplicate outpoint -> 400, malformed outpoint -> 400, capped at 500 entries, and none of it writes if any entry is bad.

kept `utxo-string` as the field name to match the existing endpoint like you said.

test plan:
- new tests for the store batch method (mixed batch, persistence, empty/duplicate rejection, atomicity on save failure, only one save call for the whole batch)
- new tests for WalletService.set_utxos_frozen (cache updates for every match not just the first one)
- new router tests (auth, mixed batch, empty/duplicate/malformed rejection, cap enforcement, blocked during a coinjoin)
- added an IDOR test for the new route same as the existing ones
- ran the full jmwallet + jmwalletd suite, all passing except the 7 pre-existing WSL-only chmod failures unrelated to this
