### PR TITLE
fix: keep declining makers off the persistent ignored list

### DIFF
--- a/taker/src/taker/coinjoin_session.py
+++ b/taker/src/taker/coinjoin_session.py
@@ -163,6 +163,10 @@ class CoinJoinSession:
         # The owner adds these nicks to the persistent ignored-maker set after
         # the round fails; replacing them here would invalidate the transaction.
         self.failed_signer_nicks: set[str] = set()
+        # Makers that answered !tx with an explicit protocol error, such as a
+        # minimum miner fee policy rejection. Declining is honest behaviour, so
+        # these nicks are kept out of the persistent ignored-maker set.
+        self.declined_signer_nicks: set[str] = set()
 
         # Addresses recorded for broadcast verification and history reconciliation.
         self.cj_destination: str = ""
@@ -219,6 +223,7 @@ class CoinJoinSession:
         self.last_used_maker_keys = set()
         self.last_failure_reason = None
         self.failed_signer_nicks = set()
+        self.declined_signer_nicks = set()
         self.cj_destination = ""
         self.taker_change_address = ""
         self._sweep_tx_fee_budget = 0
@@ -1762,6 +1767,15 @@ class CoinJoinSession:
         # Process responses
         for nick in list(self.maker_sessions.keys()):
             if nick in responses:
+                if responses[nick].get("error"):
+                    logger.warning(f"Maker {nick} declined to sign")
+                    logger.bind(sensitive=True).warning(
+                        "Maker {} declined to sign: {}", nick, responses[nick].get("data", "")
+                    )
+                    self.declined_signer_nicks.add(nick)
+                    del self.maker_sessions[nick]
+                    continue
+
                 try:
                     session = self.maker_sessions[nick]
                     if session.crypto is None:
@@ -1900,7 +1914,7 @@ class CoinJoinSession:
         missing_makers = required_makers - signed_makers
 
         if missing_makers:
-            self.failed_signer_nicks.update(missing_makers)
+            self.failed_signer_nicks.update(missing_makers - self.declined_signer_nicks)
             self.last_failure_reason = (
                 f"Missing or invalid signatures from maker(s): {', '.join(sorted(missing_makers))}"
             )

--- a/taker/tests/test_taker_signing.py
+++ b/taker/tests/test_taker_signing.py
@@ -1055,6 +1055,54 @@ class TestPhaseCollectSignaturesCompleteness:
         assert result is False
         assert "maker1" not in taker._session.maker_sessions
 
+    @pytest.mark.asyncio
+    async def test_declining_maker_is_not_added_to_failed_signers(
+        self,
+        two_maker_tx_data: CoinJoinTxData,
+    ) -> None:
+        """A maker that answers !tx with a policy error must not be blacklisted.
+
+        Rejecting a low-fee CoinJoin is honest, so the nick belongs in
+        declined_signer_nicks and must stay out of failed_signer_nicks, which
+        the caller persists to the ignored-maker file.
+        """
+        from jmcore.models import NetworkType, Offer, OfferType
+
+        offer = Offer(
+            counterparty="maker1",
+            oid=0,
+            ordertype=OfferType.SW0_RELATIVE,
+            minsize=100_000,
+            maxsize=10_000_000,
+            txfee=0,
+            cjfee="0.001",
+            fidelity_bond_value=0,
+        )
+        maker_sessions = {
+            "maker1": self._make_maker_session(
+                "maker1", offer, [{"txid": "b" * 64, "vout": 0, "value": 1_500_000}]
+            ),
+            "maker2": self._make_maker_session(
+                "maker2", offer, [{"txid": "c" * 64, "vout": 0, "value": 1_200_000}]
+            ),
+        }
+        taker = self._build_taker_with_tx(two_maker_tx_data, maker_sessions=maker_sessions)
+        taker.config.network = NetworkType.REGTEST
+        taker.directory_client.wait_for_responses = AsyncMock(
+            return_value={
+                "maker1": {
+                    "error": True,
+                    "data": "miner fee rate 1.20 sat/vB is below minimum 3.00 sat/vB",
+                }
+            }
+        )
+
+        result = await taker._session._phase_collect_signatures()
+
+        assert result is False
+        assert taker.failed_signer_nicks == {"maker2"}
+        assert taker._session.declined_signer_nicks == {"maker1"}
+
 
 # Re-export fixtures for use in conftest
 @pytest.fixture


### PR DESCRIPTION
A maker that answers `!tx` with a protocol error, such as rejecting a CoinJoin below its configured minimum miner fee rate, never sends `!sig`. It is then counted as a missing signer and written to the on-disk ignored-maker file, so a tumbler progressively and permanently blacklists honest makers whose fee policy differs from the taker's.

Track those nicks in `declined_signer_nicks` and exclude them from the set the caller persists. Makers that send no response or an invalid signature are unchanged.