### PR TITLE
fix: pay exact advertised CoinJoin fees by default

### DIFF
--- a/jmcore/src/jmcore/data/config.toml.template
+++ b/jmcore/src/jmcore/data/config.toml.template
@@ -502,12 +502,11 @@
 # max_cj_fee_rel = "0.001"    # Relative fee (0.001 = 0.1%)
 # max_sweep_fee_change = 0.8  # Relative fee tolerance for sweep transactions
 # Round each selected maker fee up to the closest same-type public quantum.
-# Disable temporarily for exact-fee compatibility with older makers that reject
-# any overpayment.
-# round_up_cj_fees = true
+# Off by default: older makers exact-match their change and reject any
+# overpayment, so rounding an off-grid offer up makes them refuse to sign.
+# round_up_cj_fees = false
 # Only consider offers already on the public fee grid. This remains effective
-# when rounding is disabled. Recommended future policy (planned default):
-# require_quantized_cj_fees = true with round_up_cj_fees = false.
+# when rounding is disabled.
 # require_quantized_cj_fees = false
 
 # Maximum inputs a single maker may contribute to the CoinJoin.

--- a/jmcore/src/jmcore/settings.py
+++ b/jmcore/src/jmcore/settings.py
@@ -1033,7 +1033,7 @@ class TakerSettings(BaseModel):
         description="Only consider offers whose advertised CoinJoin fee is on the public grid",
     )
     round_up_cj_fees: bool = Field(
-        default=True,
+        default=False,
         description="Round each selected maker fee up to the next public fee quantum",
     )
     max_sweep_fee_change: float = Field(

--- a/jmcore/tests/test_settings.py
+++ b/jmcore/tests/test_settings.py
@@ -261,7 +261,7 @@ class TestSettingsDefaults:
         assert settings.taker.max_cj_fee_abs == 500
         assert settings.taker.max_cj_fee_rel == "0.001"
         assert settings.taker.max_sweep_fee_change == 0.8
-        assert settings.taker.round_up_cj_fees is True
+        assert settings.taker.round_up_cj_fees is False
         assert settings.taker.require_quantized_cj_fees is False
         assert settings.taker.bondless_makers_allowance == 0.05
         assert settings.taker.bondless_require_zero_fee is True
@@ -1399,3 +1399,21 @@ class TestEnsureConfigFile:
         assert result == config_file
         assert config_file.exists()
         assert not (data_dir / "config.toml").exists()
+
+
+class TestDefaultCjFeeRounding:
+    """Defaults must pay the exact advertised fee for reference-maker interop."""
+
+    def test_round_up_cj_fees_defaults_off(self) -> None:
+        from jmcore.settings import TakerSettings
+
+        assert TakerSettings().round_up_cj_fees is False
+
+    def test_default_pair_does_not_overpay_off_grid_offers(self) -> None:
+        from jmcore.settings import TakerSettings
+
+        settings = TakerSettings()
+        # Rounding an off-grid offer up is what older makers reject, so it must
+        # not happen unless the operator opts in.
+        assert settings.require_quantized_cj_fees is False
+        assert settings.round_up_cj_fees is False

--- a/taker/src/taker/config.py
+++ b/taker/src/taker/config.py
@@ -114,7 +114,7 @@ class TakerConfig(WalletConfig):
         description="Only consider offers whose advertised CoinJoin fee is on the public grid",
     )
     round_up_cj_fees: bool = Field(
-        default=True,
+        default=False,
         description="Round each selected maker fee up to the next public fee quantum",
     )
     max_sweep_fee_change: float = Field(

--- a/taker/tests/test_taker_config.py
+++ b/taker/tests/test_taker_config.py
@@ -90,7 +90,7 @@ class TestTakerConfig:
         assert config.minimum_makers == 4
         assert config.min_fee_rate_sat_vb == 1.0
         assert config.min_fee_block_target == 10
-        assert config.round_up_cj_fees is True
+        assert config.round_up_cj_fees is False
         assert config.require_quantized_cj_fees is False
         assert config.bondless_makers_allowance == 0.05
         assert config.bondless_makers_allowance_require_zero_fee is True
@@ -520,3 +520,17 @@ class TestSchedule:
         schedule.advance()
         assert schedule.is_complete()
         assert schedule.current_entry() is None
+
+
+class TestDefaultCjFeeRounding:
+    def test_taker_config_round_up_cj_fees_defaults_off(self) -> None:
+        from jmcore.models import NetworkType
+
+        from taker.config import TakerConfig
+
+        config = TakerConfig(
+            mnemonic="test " * 12,
+            directory_servers=["localhost:5222"],
+            network=NetworkType.REGTEST,
+        )
+        assert config.round_up_cj_fees is False


### PR DESCRIPTION
`round_up_cj_fees` defaults to `true` while `require_quantized_cj_fees` defaults to `false`, so off-grid offers are selected and then paid above the advertised fee. Older makers exact-match their change and refuse to sign the overpayment, which `test_rounded_fees_are_rejected_by_legacy_reference_makers` already asserts, so the default combination breaks reference-maker interop.

Default `round_up_cj_fees` to `false`. Operators who want grid fees can still opt in, and `require_quantized_cj_fees` keeps working on its own.