### PR TITLE
fix: keep zero relative CoinJoin fees free

### DIFF
--- a/jmcore/src/jmcore/fee_quantization.py
+++ b/jmcore/src/jmcore/fee_quantization.py
@@ -16,10 +16,13 @@ from __future__ import annotations
 from decimal import ROUND_HALF_EVEN, Decimal
 
 # Relative-fee grid (fraction of the CoinJoin amount). Base-10 mantissas:
-#   0.002%, 0.005%, 0.01%, 0.02%, 0.05%, 0.1%, 0.2%, 0.5%, 1%, 2%, 5%, 10%
+#   0%, 0.002%, 0.005%, 0.01%, 0.02%, 0.05%, 0.1%, 0.2%, 0.5%, 1%, 2%, 5%, 10%
+# The leading 0 is the free-maker band, mirroring QUANT_ABS: a maker that
+# advertises a zero relative fee must not be rounded up into a paid band.
 QUANT_REL: tuple[Decimal, ...] = tuple(
     Decimal(v)
     for v in (
+        "0",
         "0.00002",
         "0.00005",
         "0.0001",

--- a/jmcore/tests/test_fee_quantization.py
+++ b/jmcore/tests/test_fee_quantization.py
@@ -29,7 +29,8 @@ class TestGridShape:
         assert len(set(values)) == len(values)
 
     def test_smallest_rel_quantum(self) -> None:
-        assert QUANT_REL[0] == Decimal("0.00002")
+        assert QUANT_REL[0] == Decimal("0")
+        assert QUANT_REL[1] == Decimal("0.00002")
 
     def test_smallest_abs_quantum(self) -> None:
         # The grid starts at 0, the free-maker band.
@@ -51,8 +52,8 @@ class TestQuantizeRelDown:
     def test_floor_to_grid(self, rel_fee: str, expected: Decimal) -> None:
         assert quantize_rel_down(rel_fee) == expected
 
-    def test_below_grid_returns_none(self) -> None:
-        assert quantize_rel_down("0.00001") is None
+    def test_below_smallest_paid_band_floors_to_free(self) -> None:
+        assert quantize_rel_down("0.00001") == Decimal("0")
 
     def test_accepts_float_and_decimal(self) -> None:
         assert quantize_rel_down(0.001) == Decimal("0.001")
@@ -109,3 +110,19 @@ class TestRelQuantumToSats:
 
     def test_zero_amount(self) -> None:
         assert rel_quantum_to_sats(Decimal("0.001"), 0) == 0
+
+
+class TestFreeMakerBand:
+    """A zero relative fee is on the grid, mirroring the absolute free band."""
+
+    def test_rel_up_keeps_zero_free(self) -> None:
+        assert quantize_rel_up(Decimal("0")) == Decimal("0")
+
+    def test_rel_down_keeps_zero_free(self) -> None:
+        assert quantize_rel_down(Decimal("0")) == Decimal("0")
+
+    def test_zero_is_on_the_relative_grid(self) -> None:
+        assert Decimal("0") in QUANT_REL
+
+    def test_smallest_paid_band_still_rounds_up(self) -> None:
+        assert quantize_rel_up(Decimal("0.00001")) == Decimal("0.00002")


### PR DESCRIPTION
`QUANT_REL` starts at `0.00002` while `QUANT_ABS` starts at `0`, so a maker advertising a zero relative fee is rounded up into the smallest paid band: 10,000 sats on a 5 BTC CoinJoin. It also contradicts `bondless_require_zero_fee`, which selects those makers precisely because they charge nothing, and excludes them from `require_quantized_cj_fees`.

Add the free band to the relative grid so it mirrors the absolute grid.