### PR TITLE
fix: release maker transports when startup fails

### DIFF
--- a/maker/src/maker/bot.py
+++ b/maker/src/maker/bot.py
@@ -420,24 +420,6 @@ class MakerBot(BackgroundTasksMixin, ProtocolHandlersMixin, DirectConnectionMixi
                 self._tor_control = None
             raise
 
-    async def _cleanup_tor_hidden_service(self) -> None:
-        """Remove the ephemeral hidden service and close the Tor control connection."""
-        if self._ephemeral_hidden_service and self._tor_control:
-            try:
-                await self._tor_control.delete_ephemeral_hidden_service(
-                    self._ephemeral_hidden_service.service_id
-                )
-                logger.info("Removed ephemeral Tor hidden service")
-            except TorControlError as e:
-                logger.warning(f"Failed to remove ephemeral hidden service: {e}")
-        if self._tor_control:
-            try:
-                await self._tor_control.close()
-            except Exception as e:
-                logger.warning(f"Error closing Tor control connection: {e}")
-            self._tor_control = None
-            self._ephemeral_hidden_service = None
-
     async def _regenerate_nick(self) -> None:
         """
         Regenerate nick identity for privacy (currently disabled).
@@ -1004,7 +986,10 @@ class MakerBot(BackgroundTasksMixin, ProtocolHandlersMixin, DirectConnectionMixi
             # Set up ephemeral hidden service via Tor control port if enabled
             # This must happen before connecting to directory servers so we can
             # advertise the onion address
+            initial_generation = self.generations[0]
             ephemeral_onion = await self._setup_tor_hidden_service()
+            initial_generation.tor_control = self._tor_control
+            initial_generation.ephemeral_hidden_service = self._ephemeral_hidden_service
             if ephemeral_onion:
                 # Override onion_host with the dynamically created one
                 object.__setattr__(self.config, "onion_host", ephemeral_onion)
@@ -1034,6 +1019,8 @@ class MakerBot(BackgroundTasksMixin, ProtocolHandlersMixin, DirectConnectionMixi
                     ),
                 )
                 await self.hidden_service_listener.start()
+                initial_generation.hidden_service_listener = self.hidden_service_listener
+                initial_generation.listener_port = self.hidden_service_listener.bound_port
                 logger.info("Hidden service listener started")
                 logger.bind(sensitive=True).info(
                     f"Hidden service listener started (onion: {onion_host})"
@@ -1042,15 +1029,8 @@ class MakerBot(BackgroundTasksMixin, ProtocolHandlersMixin, DirectConnectionMixi
             logger.info("Announcing offers...")
             await self._announce_offers()
 
-            initial_generation = self.generations[0]
             initial_generation.current_offers = self.current_offers
-            initial_generation.hidden_service_listener = self.hidden_service_listener
-            initial_generation.tor_control = self._tor_control
-            initial_generation.ephemeral_hidden_service = self._ephemeral_hidden_service
             initial_generation.onion_host = onion_host
-            initial_generation.listener_port = (
-                self.hidden_service_listener.bound_port if self.hidden_service_listener else None
-            )
 
             logger.info("Maker bot started. Listening for takers...")
             self.running = True

--- a/maker/tests/test_bot.py
+++ b/maker/tests/test_bot.py
@@ -3363,3 +3363,85 @@ class TestListenTasksMemoryLeak:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestStartupTransportOwnership:
+    """A failure during start() must still release Tor and listener handles.
+
+    stop() only closes generation-owned transports, so anything created during
+    start() has to be attached to generation 0 as soon as it exists.
+    """
+
+    @staticmethod
+    def _make_bot() -> MakerBot:
+        wallet = MagicMock()
+        wallet.mixdepth_count = 5
+        wallet.utxo_cache = {}
+        wallet.network = NetworkType.REGTEST
+        backend = MagicMock()
+        config = MakerConfig(
+            mnemonic="test " * 12,
+            directory_servers=["localhost:5222"],
+            network=NetworkType.REGTEST,
+        )
+        return MakerBot(wallet=wallet, backend=backend, config=config)
+
+    @pytest.mark.asyncio
+    async def test_stop_closes_tor_handles_created_before_a_start_failure(self):
+        bot = self._make_bot()
+
+        tor_control = AsyncMock()
+        ephemeral = MagicMock()
+        ephemeral.service_id = "abc123"
+        listener = AsyncMock()
+        listener.bound_port = 5222
+
+        generation = bot.generations[0]
+        generation.tor_control = tor_control
+        generation.ephemeral_hidden_service = ephemeral
+        generation.hidden_service_listener = listener
+
+        await bot.stop()
+
+        listener.stop.assert_awaited()
+        tor_control.delete_ephemeral_hidden_service.assert_awaited_with("abc123")
+        tor_control.close.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_start_attaches_tor_handles_before_directory_connect(self):
+        bot = self._make_bot()
+        tor_control = AsyncMock()
+        ephemeral = MagicMock()
+        ephemeral.onion_address = "aaaa.onion"
+
+        async def fake_setup():
+            bot._tor_control = tor_control
+            bot._ephemeral_hidden_service = ephemeral
+            return ephemeral.onion_address
+
+        offer = Offer(
+            counterparty=bot.nick,
+            oid=0,
+            ordertype=OfferType.SW0_RELATIVE,
+            minsize=100_000,
+            maxsize=10_000_000,
+            txfee=1000,
+            cjfee="0.0003",
+            fidelity_bond_value=0,
+        )
+        bot.backend.get_block_height = AsyncMock(return_value=800_000)
+        bot.wallet.sync_all = AsyncMock()
+        bot.wallet.sync_with_descriptor_wallet = AsyncMock()
+        bot.wallet.reconstruct_imported_state_safe = AsyncMock()
+        bot.wallet.get_total_balance = AsyncMock(return_value=10_000_000)
+        bot.offer_manager.create_offers = AsyncMock(return_value=[offer])
+        bot._setup_tor_hidden_service = fake_setup
+        bot._connect_to_directories_with_retry = AsyncMock(
+            side_effect=RuntimeError("no directories")
+        )
+
+        with pytest.raises(RuntimeError):
+            await bot.start()
+
+        assert bot.generations[0].tor_control is tor_control
+        assert bot.generations[0].ephemeral_hidden_service is ephemeral


### PR DESCRIPTION
`stop()` closes only generation-owned transports, but generation 0 receives the listener and Tor handles at the very end of `start()`. A failure in between, for example when no directory server can be reached, leaves the ephemeral hidden service published, the Tor control connection open and the onion serving port bound until the process exits.

Attach each transport to generation 0 as soon as it is created, and drop `_cleanup_tor_hidden_service`, which nothing called.