### PR TITLE
fix: bound how often !fill refreshes the maker fee policy

### DIFF
--- a/maker/src/maker/bot.py
+++ b/maker/src/maker/bot.py
@@ -65,6 +65,7 @@ from maker.rate_limiting import (
 # Approximately 64MB of memory for str->float mapping (including overhead)
 MAX_LOG_RATE_LIMIT_ENTRIES = 200000
 _DETACHED_SHUTDOWN_GRACE_SEC = 0.5
+MIN_FEE_POLICY_TTL_SEC = 60.0
 
 
 def _get_fidelity_bond_linkable_utxos(
@@ -98,6 +99,7 @@ class MakerBot(BackgroundTasksMixin, ProtocolHandlersMixin, DirectConnectionMixi
         self.config = config
         self._static_onion_configured = config.onion_host is not None
         self.minimum_fee_rate_sat_vb = config.min_fee_rate_sat_vb
+        self._minimum_fee_policy_resolved_at: float | None = None
         self._minimum_fee_policy_warning_emitted = False
 
         # Create nick identity for signing messages
@@ -462,12 +464,20 @@ class MakerBot(BackgroundTasksMixin, ProtocolHandlersMixin, DirectConnectionMixi
                 )
                 self._minimum_fee_policy_warning_emitted = True
             return
+        # !fill refreshes this policy, so an unauthenticated peer can drive the
+        # backend calls below. The floor tracks mempool conditions that move at
+        # most once per block, so a recent value is reused instead.
+        now = time.monotonic()
+        resolved_at = self._minimum_fee_policy_resolved_at
+        if resolved_at is not None and now - resolved_at < MIN_FEE_POLICY_TTL_SEC:
+            return
         self.minimum_fee_rate_sat_vb = await resolve_min_fee_rate(
             self.backend,
             static_floor=self.config.min_fee_rate_sat_vb,
             block_target=self.config.min_fee_block_target,
             max_fee_rate=self.config.max_fee_rate_sat_vb,
         )
+        self._minimum_fee_policy_resolved_at = now
         if announce:
             logger.info(
                 "Resolved minimum CoinJoin miner fee rate: "

--- a/maker/tests/test_maker_protocol.py
+++ b/maker/tests/test_maker_protocol.py
@@ -1434,7 +1434,7 @@ async def test_neutrino_style_maker_warns_and_skips_minimum_fee_policy():
 async def test_full_node_maker_refreshes_minimum_fee_policy_before_new_sessions():
     from unittest.mock import AsyncMock, MagicMock
 
-    from maker.bot import MakerBot
+    from maker.bot import MIN_FEE_POLICY_TTL_SEC, MakerBot
 
     bot = MakerBot.__new__(MakerBot)
     bot.minimum_fee_rate_sat_vb = 1.0
@@ -1449,12 +1449,20 @@ async def test_full_node_maker_refreshes_minimum_fee_policy_before_new_sessions(
     bot.backend.can_estimate_fee.return_value = True
     bot.backend.get_mempool_min_fee = AsyncMock(return_value=None)
     bot.backend.estimate_fee = AsyncMock(side_effect=[2.0, 3.0])
+    bot._minimum_fee_policy_resolved_at = None
 
     await bot._initialize_minimum_fee_policy(announce=False)
     first_threshold = bot.minimum_fee_rate_sat_vb
+    # A second call inside the TTL reuses the resolved floor, so !fill cannot
+    # drive one backend round trip per message.
+    await bot._initialize_minimum_fee_policy(announce=False)
+    assert first_threshold == 2.0
+    assert bot.minimum_fee_rate_sat_vb == 2.0
+    assert bot.backend.estimate_fee.await_args_list == [((10,), {})]
+
+    bot._minimum_fee_policy_resolved_at -= MIN_FEE_POLICY_TTL_SEC
     await bot._initialize_minimum_fee_policy(announce=False)
 
-    assert first_threshold == 2.0
     assert bot.minimum_fee_rate_sat_vb == 3.0
     assert bot.backend.estimate_fee.await_args_list == [((10,), {}), ((10,), {})]
 


### PR DESCRIPTION
Every `!fill` re-resolves the minimum miner fee policy, and each refresh awaits a mempool minimum lookup plus a fee estimate on the directory message loop. Any peer can therefore drive two backend round trips per message against the maker's node without authenticating.

Cache the resolved floor for 60 seconds. It tracks mempool conditions that move at most once per block, so sessions still start from a current value.