### PR TITLE
fix: read wallet history under a shared lock

### DIFF
--- a/jmwallet/src/jmwallet/history.py
+++ b/jmwallet/src/jmwallet/history.py
@@ -284,13 +284,17 @@ def _history_lock_path(history_path: Path) -> Path:
 
 
 @contextmanager
-def _history_lock(history_path: Path) -> Iterator[None]:
-    """Serialize history mutations through a stable owner-only sidecar lock."""
+def _history_lock(history_path: Path, *, shared: bool = False) -> Iterator[None]:
+    """Serialize history access through a stable owner-only sidecar lock.
+
+    Readers pass ``shared=True`` so they do not queue behind each other. Only
+    POSIX supports a shared mode; the Windows fallback stays exclusive.
+    """
     lock_fd = _open_owner_only_regular(_history_lock_path(history_path), os.O_RDWR | os.O_CREAT)
     locked = False
     try:
         if fcntl is not None:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            fcntl.flock(lock_fd, fcntl.LOCK_SH if shared else fcntl.LOCK_EX)
         elif msvcrt is not None:  # pragma: no cover - Windows
             if os.fstat(lock_fd).st_size == 0:
                 os.write(lock_fd, b"\0")
@@ -330,11 +334,24 @@ def _resolve_history_path_unlocked(history_path: Path) -> Path:
 
 
 @contextmanager
-def _locked_history_path(data_dir: Path | None = None) -> Iterator[Path]:
-    """Yield the active history path while holding the exclusive advisory lock."""
+def _locked_history_path(data_dir: Path | None = None, *, shared: bool = False) -> Iterator[Path]:
+    """Yield the active history path while holding the advisory lock."""
     canonical_path = _get_history_path(data_dir)
-    with _history_lock(canonical_path):
+    with _history_lock(canonical_path, shared=shared):
         yield _resolve_history_path_unlocked(canonical_path)
+
+
+def _history_header_is_stale(data_dir: Path | None = None) -> bool:
+    """Return whether the on-disk history header needs migrating."""
+    try:
+        canonical_path = _get_history_path(data_dir)
+        history_path = _resolve_history_path_unlocked(canonical_path)
+        if not history_path.exists():
+            return False
+        actual = _read_csv_header(history_path)
+    except Exception:
+        return False
+    return actual is not None and actual != _get_fieldnames()
 
 
 def _get_fieldnames() -> list[str]:
@@ -751,13 +768,19 @@ def read_history(
         List of TransactionHistoryEntry objects
     """
     try:
-        with _locked_history_path(data_dir) as history_path:
+        # Header migration rewrites the file, so it needs the exclusive lock.
+        # Taking it only when the header is actually stale lets the common
+        # read path use a shared lock instead of serializing every reader.
+        if _history_header_is_stale(data_dir):
+            with _locked_history_path(data_dir) as history_path:
+                try:
+                    _ensure_history_header_current(history_path)
+                except HistoryWriteError as exc:
+                    logger.warning(f"History header migration failed during read: {exc}")
+
+        with _locked_history_path(data_dir, shared=True) as history_path:
             if not history_path.exists():
                 return []
-            try:
-                _ensure_history_header_current(history_path)
-            except HistoryWriteError as exc:
-                logger.warning(f"History header migration failed during read: {exc}")
             entries = _read_history_entries_unlocked(history_path)
     except Exception as e:
         logger.error(f"Failed to read history: {e}")

--- a/jmwallet/tests/test_history.py
+++ b/jmwallet/tests/test_history.py
@@ -4198,3 +4198,49 @@ class TestYieldGeneratorReport:
         rows = format_yield_generator_report(temp_data_dir, wallet_fingerprint="aaaaaaaa")
         assert len(rows) == 2  # only wallet aaaaaaaa's row
         assert rows[-1].split(",")[1] == "1"
+
+
+class TestHistoryReadLockIsShared:
+    """Readers must not queue behind each other on the history lock."""
+
+    def test_read_history_proceeds_while_a_shared_lock_is_held(self, tmp_path) -> None:
+        import fcntl
+        import os
+        import threading
+
+        from jmwallet.history import (
+            HISTORY_LOCK_SUFFIX,
+            TransactionHistoryEntry,
+            _get_history_path,
+            append_history_entry,
+            read_history,
+        )
+
+        append_history_entry(
+            TransactionHistoryEntry(
+                timestamp="2026-01-01T00:00:00Z",
+                txid="ab" * 32,
+                role="taker",
+                cj_amount=100_000,
+            ),
+            data_dir=tmp_path,
+        )
+
+        lock_path = _get_history_path(tmp_path).with_name(
+            _get_history_path(tmp_path).name + HISTORY_LOCK_SUFFIX
+        )
+        holder = os.open(lock_path, os.O_RDWR | os.O_CREAT)
+        result: list[list] = []
+        try:
+            fcntl.flock(holder, fcntl.LOCK_SH)
+            reader = threading.Thread(target=lambda: result.append(read_history(data_dir=tmp_path)))
+            reader.start()
+            reader.join(timeout=5.0)
+            assert not reader.is_alive(), "read_history blocked behind a shared lock"
+        finally:
+            fcntl.flock(holder, fcntl.LOCK_UN)
+            os.close(holder)
+            reader.join(timeout=5.0)
+
+        assert len(result) == 1
+        assert len(result[0]) == 1


### PR DESCRIPTION
`read_history` takes the exclusive advisory lock for a pure read, so every reader serializes behind every other reader as well as behind writers. The only reason it needed exclusivity was the header migration, which rewrites the file.

Probe the header first and take the exclusive lock only when a migration is actually due, then read under a shared lock. Writers are unchanged, so a read still never observes a partial write.