### PR TITLE
fix: bound the address allocation candidate search

### DIFF
--- a/jmwallet/src/jmwallet/wallet/service.py
+++ b/jmwallet/src/jmwallet/wallet/service.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable
-from itertools import count
+from itertools import count, islice
 from pathlib import Path
 from threading import Lock
 from typing import Any
@@ -32,10 +32,15 @@ from jmwallet.wallet.utxo_metadata import (
     load_metadata_store,
 )
 
+# Upper bound on how far one allocation may walk a branch looking for an
+# address that is neither used nor already reserved.
+MAX_ADDRESS_ALLOCATION_CANDIDATES = 10_000
+
 # Re-export constants so external code importing from service.py still works
 __all__ = [
     "DEFAULT_SCAN_RANGE",
     "FIDELITY_BOND_BRANCH",
+    "MAX_ADDRESS_ALLOCATION_CANDIDATES",
     "WalletService",
 ]
 
@@ -893,7 +898,13 @@ class WalletService(
         """
         with self._address_allocation_lock:
             start_index = self.get_next_address_index(mixdepth, change)
-            candidates = (self.get_address(mixdepth, change, index) for index in count(start_index))
+            # Bounded: the metadata store consumes this while holding its
+            # cross-process lock, so an endless sequence would spin there
+            # instead of surfacing AddressReservationError.
+            candidates = (
+                self.get_address(mixdepth, change, index)
+                for index in islice(count(start_index), MAX_ADDRESS_ALLOCATION_CANDIDATES)
+            )
 
             store = self.metadata_store
             if store is not None:
@@ -907,14 +918,15 @@ class WalletService(
                     | self.reserved_addresses
                     | self.issued_receive_addresses
                 )
-                address = next(
+                selected = next(
                     (candidate for candidate in candidates if candidate not in unavailable),
                     None,
                 )
-                if address is None:
+                if selected is None:
                     raise AddressReservationError(
                         "No available address candidates could be reserved"
                     )
+                address = selected
 
             # Update local state only after the reservation has succeeded.
             self.reserved_addresses.add(address)

--- a/jmwallet/tests/test_address.py
+++ b/jmwallet/tests/test_address.py
@@ -10,6 +10,8 @@ These tests ensure that:
 
 from __future__ import annotations
 
+import threading
+
 import pytest
 from bitcointx import ChainParams
 from bitcointx.wallet import CCoinAddress, CCoinAddressError
@@ -152,3 +154,42 @@ class TestAddressValidation:
         """Uppercase addresses (e.g. from QR decoders) must be accepted."""
         spk = address_to_scriptpubkey("mainnet", "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4")
         assert spk.hex() == "0014751e76e8199196d454941c45d1b3a323f1433bd6"
+
+
+class TestAddressAllocationIsBounded:
+    """Allocation must fail loudly instead of deriving addresses forever."""
+
+    @staticmethod
+    def _wallet():
+        from unittest.mock import MagicMock
+
+        from jmwallet.wallet.service import WalletService
+
+        wallet = WalletService.__new__(WalletService)
+        wallet._address_allocation_lock = threading.Lock()
+        wallet.metadata_store = None
+        wallet.reserved_addresses = set()
+        wallet.issued_receive_addresses = set()
+        wallet.reserved_address_labels = {}
+        wallet.addresses_with_history = set()
+        wallet.get_next_address_index = MagicMock(return_value=0)
+        wallet.get_address = lambda mixdepth, change, index: f"addr-{mixdepth}-{change}-{index}"
+        return wallet
+
+    def test_raises_when_every_candidate_in_range_is_reserved(self) -> None:
+        from jmwallet.wallet.service import MAX_ADDRESS_ALLOCATION_CANDIDATES
+        from jmwallet.wallet.utxo_metadata import AddressReservationError
+
+        wallet = self._wallet()
+        wallet.reserved_addresses = {
+            f"addr-0-1-{index}" for index in range(MAX_ADDRESS_ALLOCATION_CANDIDATES)
+        }
+
+        with pytest.raises(AddressReservationError):
+            wallet.allocate_output_address(0, 1)
+
+    def test_allocates_the_first_free_candidate(self) -> None:
+        wallet = self._wallet()
+        wallet.reserved_addresses = {"addr-0-1-0", "addr-0-1-1"}
+
+        assert wallet.allocate_output_address(0, 1) == "addr-0-1-2"


### PR DESCRIPTION
`allocate_output_address` builds an endless candidate generator. `reserve_first_available_address` consumes it while holding the metadata store's cross-process file lock, so a branch whose next addresses are all used or reserved spins there deriving addresses forever instead of raising. The ephemeral path has the mirror problem: the `next(..., None)` default can never be reached, making `AddressReservationError` unreachable.

Cap the search at `MAX_ADDRESS_ALLOCATION_CANDIDATES` so both paths terminate and surface the existing error.