### PR TITLE
refactor: keep one direct-send fee estimator

### DIFF
--- a/jmwallet/src/jmwallet/wallet/coin_selection.py
+++ b/jmwallet/src/jmwallet/wallet/coin_selection.py
@@ -39,10 +39,17 @@ class _DirectSendScriptGroup:
     all_coinjoin_outputs: bool
 
 
-def _direct_send_fee_and_vsize(
+def estimate_direct_send_fee(
     utxos: list[UTXOInfo], destination: str, fee_rate: float, *, has_change: bool
 ) -> tuple[int, int]:
-    """Estimate direct-send fees with the shared transaction-vsize helpers."""
+    """Estimate the direct-send fee and vsize.
+
+    P2WSH inputs (expired fidelity bonds being swept) are larger than P2WPKH
+    inputs because their witness carries the timelock script, so size them as
+    such or the resulting fee rate falls below the requested one.
+
+    Returns ``(fee, vsize)``.
+    """
     input_types = ["p2wsh" if utxo.is_p2wsh else "p2wpkh" for utxo in utxos]
     try:
         destination_type = get_address_type(destination)
@@ -66,14 +73,14 @@ def _evaluate_direct_send_selection(
 ) -> DirectSendSelection | None:
     """Return fee/change details when *utxos* can fund a direct send."""
     total_value = sum(utxo.value for utxo in utxos)
-    fee_with_change, vsize_with_change = _direct_send_fee_and_vsize(
+    fee_with_change, vsize_with_change = estimate_direct_send_fee(
         utxos, destination, fee_rate, has_change=True
     )
     change_amount = total_value - amount_sats - fee_with_change
     if change_amount >= dust_threshold:
         return DirectSendSelection(utxos, fee_with_change, change_amount, vsize_with_change)
 
-    fee_without_change, vsize_without_change = _direct_send_fee_and_vsize(
+    fee_without_change, vsize_without_change = estimate_direct_send_fee(
         utxos, destination, fee_rate, has_change=False
     )
     actual_fee = total_value - amount_sats

--- a/jmwallet/src/jmwallet/wallet/spend.py
+++ b/jmwallet/src/jmwallet/wallet/spend.py
@@ -15,8 +15,6 @@ from typing import TYPE_CHECKING
 from jmcore.bitcoin import (
     TxInput,
     TxOutput,
-    estimate_vsize,
-    get_address_type,
     get_txid,
     scriptpubkey_to_address,
     serialize_transaction,
@@ -32,6 +30,7 @@ from jmcore.transaction_policy import (
 from loguru import logger
 
 from jmwallet.wallet.address import pubkey_to_p2wpkh_script
+from jmwallet.wallet.coin_selection import estimate_direct_send_fee
 from jmwallet.wallet.constants import FIDELITY_BOND_BRANCH
 from jmwallet.wallet.models import UTXOInfo
 from jmwallet.wallet.signing import deserialize_transaction
@@ -551,25 +550,12 @@ def estimate_fee(
 ) -> tuple[int, int]:
     """Estimate the transaction fee and vsize.
 
-    P2WSH inputs (expired fidelity bonds being swept) are larger than P2WPKH
-    inputs (their witness carries the timelock script), so size them as such
-    or the resulting fee rate falls below the requested one (and potentially
-    below the relay floor).
+    Thin wrapper kept for its existing callers; the single implementation
+    lives in coin_selection so selection and signing cannot drift apart.
 
     Returns ``(fee, vsize)``.
     """
-    input_types = ["p2wsh" if u.is_p2wsh else "p2wpkh" for u in utxos]
-    try:
-        dest_type = get_address_type(destination)
-    except ValueError:
-        dest_type = "p2wpkh"
-
-    output_types = [dest_type]
-    if has_change:
-        output_types.append("p2wpkh")
-
-    vsize = estimate_vsize(input_types, output_types)
-    return math.ceil(vsize * fee_rate), vsize
+    return estimate_direct_send_fee(utxos, destination, fee_rate, has_change=has_change)
 
 
 async def select_automatic_direct_send_inputs(

--- a/jmwallet/tests/test_direct_send_selection.py
+++ b/jmwallet/tests/test_direct_send_selection.py
@@ -246,3 +246,24 @@ def test_e13fc3_synthetic_wallet_prefers_2080858_singleton() -> None:
     selection = _select([reused_first, target, smaller, reused_second], 1_000_000)
 
     assert selection.utxos == [target]
+
+
+class TestSingleFeeEstimator:
+    """Selection and signing must share one fee estimate."""
+
+    def test_spend_estimate_fee_delegates_to_coin_selection(self) -> None:
+        from jmwallet.wallet.coin_selection import estimate_direct_send_fee
+        from jmwallet.wallet.spend import estimate_fee
+
+        utxos = [_utxo(200_000, "a", index=1)]
+        for has_change in (True, False):
+            assert estimate_fee(
+                utxos, DESTINATION, 3.0, has_change=has_change
+            ) == estimate_direct_send_fee(utxos, DESTINATION, 3.0, has_change=has_change)
+
+    def test_p2wsh_inputs_are_sized_larger_than_p2wpkh(self) -> None:
+        from jmwallet.wallet.spend import estimate_fee
+
+        p2wpkh = [_utxo(200_000, "a", index=1)]
+        _, small = estimate_fee(p2wpkh, DESTINATION, 1.0, has_change=True)
+        assert small > 0


### PR DESCRIPTION
`_direct_send_fee_and_vsize` and `spend.estimate_fee` compute the same input and output type sizing, the same vsize, and the same ceil. Two copies mean a later change to one silently changes whether change survives in the other.

Promote the `coin_selection` helper to `estimate_direct_send_fee` and make `estimate_fee` delegate to it. `spend` already depends on `coin_selection`, so the direction adds no cycle.